### PR TITLE
feat(api): add /api/version endpoint

### DIFF
--- a/rocketgpt_v3_full/webapp/next/app/api/version/route.ts
+++ b/rocketgpt_v3_full/webapp/next/app/api/version/route.ts
@@ -1,0 +1,22 @@
+﻿import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic"; // ensure fresh response on each request
+
+export async function GET() {
+  const version = process.env.NEXT_PUBLIC_APP_VERSION
+    || process.env.VERCEL_GIT_COMMIT_SHA
+    || "dev";
+  const ts = new Date().toISOString();
+
+  return NextResponse.json(
+    { ok: true, version, ts },
+    {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+        "Pragma": "no-cache",
+        "Expires": "0"
+      }
+    }
+  );
+}


### PR DESCRIPTION
Adds a minimal /api/version returning { ok, version, ts }. Uses NEXT_PUBLIC_APP_VERSION or VERCEL_GIT_COMMIT_SHA. No caching.