### PR TITLE
Fix: Use relative URLs for dashboard API fetches (Limits/Health 401 Fix)

### DIFF
--- a/rocketgpt_v3_full/webapp/next/app/lib/api.ts
+++ b/rocketgpt_v3_full/webapp/next/app/lib/api.ts
@@ -3,22 +3,11 @@
   init?: RequestInit,
   timeoutMs = 4000
 ): Promise<{ ok: boolean; data?: T; error?: string }> {
-
-  // 1) Convert relative URL → absolute URL when running on server
-  let finalUrl = url;
-  if (url.startsWith("/")) {
-    // Running on server-side renderer?
-    if (typeof window === "undefined") {
-      const base =
-        process.env.VERCEL_URL
-          ? `https://${process.env.VERCEL_URL}`
-          : process.env.NEXT_PUBLIC_BASE_URL
-          ? process.env.NEXT_PUBLIC_BASE_URL
-          : "http://localhost:3000";
-
-      finalUrl = base + url;
-    }
-  }
+  // Always use the URL as given.
+  // - On the client: this will be a normal relative fetch (`/api/...`).
+  // - On the server (App Router): Next.js will internally resolve `/api/...`
+  //   against the same deployment without needing an absolute base URL.
+  const finalUrl = url;
 
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), timeoutMs);
@@ -30,11 +19,12 @@
       cache: "no-store",
     });
 
-    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+    if (!res.ok) {
+      return { ok: false, error: `HTTP ${res.status}` };
+    }
 
     const data = (await res.json()) as T;
     return { ok: true, data };
-
   } catch (e: any) {
     return { ok: false, error: e?.message ?? "fetch-error" };
   } finally {


### PR DESCRIPTION
This PR fixes the dashboard UI by ensuring all server-side API calls use relative URLs instead of absolute Vercel URLs, resolving the 401 errors on production.