### PR TITLE
RGPT-P1: Document Phase-1 gate requirements

### DIFF
--- a/docs/ops/markers/RGPT-P1/P1_GO_LIVE_PROOF.md
+++ b/docs/ops/markers/RGPT-P1/P1_GO_LIVE_PROOF.md
@@ -3,3 +3,9 @@
 - UTC/Local Stamp: 2026-01-30T20:13:01+05:30
 - Purpose: Prove branch protection + required checks + policy_gate context publish + auto-merge chain
 - Branch: rgpt/p1-proof-policy-gate
+
+## Phase-1 Gate Note (2026-01-31)
+- Final enforcement source: GitHub Ruleset 'Main Branch Protection' (id 9284184)
+- Required checks: policy_gate, smoke (integration 15368)
+- Legacy branch protection required_status_checks cleared to avoid drift.
+- build-test is not required because no check-run named 'build-test' is produced in current CI.


### PR DESCRIPTION
Docs-only: records final Phase-1 required checks (policy_gate + smoke via ruleset) and removal of legacy required_status_checks to avoid drift.