### PR TITLE
chore: trigger Vercel rebuild for Phase-1 chat fixes

### DIFF
--- a/rocketgpt_v3_full/webapp/next/app/home/ChatWorkspace/HomeChatContext.tsx
+++ b/rocketgpt_v3_full/webapp/next/app/home/ChatWorkspace/HomeChatContext.tsx
@@ -27,6 +27,7 @@ const HomeChatContext = createContext<HomeChatContextValue | null>(null);
 /**
  * HomeChatProvider
  * Provides shared chat state across the Home workspace.
+ * Phase-1: Messages start empty (no demo seeding).
  */
 export function HomeChatProvider({ children }: { children: ReactNode }) {
   const [messages, setMessages] = useState<HomeChatMessage[]>([]);


### PR DESCRIPTION
## Summary

Previous deploy was skipped by Vercel "Ignored Build Step".
This commit forces a rebuild to deploy the P1 chat fixes.

## Fixes Included in PR #288 (now deploying)
- Empty initial messages (no demo seeding)
- New Chat button clears transcript via shared context
- Sessions hidden for anonymous users

## Verification
- Check rocketgpt.dev after merge shows:
  - Empty chat transcript on load
  - "Sign in to see your chat history" in sessions pane
  - New button clears any messages

---
🤖 Generated with [Claude Code](https://claude.ai/code)