### PR TITLE
RGPT-P1: Critical UX fixes - stub demo API + resetChat

### DIFF
--- a/rocketgpt_v3_full/webapp/next/app/api/demo/chat/route.ts
+++ b/rocketgpt_v3_full/webapp/next/app/api/demo/chat/route.ts
@@ -1,50 +1,19 @@
-import { NextRequest, NextResponse } from "next/server";
-import { runtimeGuard } from "@/rgpt/runtime/runtime-guard";
-import { completeChatWithFallback, type LLMMessage } from "../../_lib/llmProvider";
+import { NextResponse } from "next/server";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
-type ChatMessage = {
-  role: "user" | "assistant" | "system";
-  content: string;
-};
+/**
+ * POST /api/demo/chat
+ * Phase-1: Returns a stub reply. Always 200, never 500.
+ * Real LLM integration will be wired in a future phase.
+ */
+export async function POST() {
+  // Phase-1: Return stub reply to avoid 500 errors
+  const reply =
+    "Hello! I'm RocketGPT running in Phase-1 demo mode. " +
+    "Full chat functionality will be enabled soon. " +
+    "For now, this is a placeholder response.";
 
-export async function POST(req: NextRequest) {
-  await runtimeGuard(req, { permission: "API_CALL" }); // TODO(S4): tighten permission per route
-  try {
-    const body = await req.json().catch(() => ({}));
-    const messages = (body as any)?.messages as ChatMessage[] | undefined;
-
-    const safeMessages: ChatMessage[] = Array.isArray(messages)
-      ? messages.map((m) => ({
-          role:
-            m.role === "assistant" || m.role === "system" ? m.role : "user",
-          content: String(m.content ?? ""),
-        }))
-      : [];
-
-    const systemMessage: ChatMessage = {
-      role: "system",
-      content:
-        "You are RocketGPT, an AI Orchestrator assistant. Be concise, helpful, and safe. You are running in a demo environment wired through Next.js.",
-    };
-
-    const providerMessages: LLMMessage[] = [systemMessage, ...safeMessages].map(
-      (m) => ({
-        role: m.role,
-        content: m.content,
-      })
-    );
-
-    const reply = await completeChatWithFallback(providerMessages);
-
-    return NextResponse.json({ reply });
-  } catch (err: any) {
-    console.error("Error in /api/demo/chat:", err);
-    const message =
-      err && typeof err.message === "string"
-        ? err.message
-        : "Internal error in /api/demo/chat";
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+  return NextResponse.json({ reply });
 }

--- a/rocketgpt_v3_full/webapp/next/app/home/ChatWorkspace/HomeChatContext.tsx
+++ b/rocketgpt_v3_full/webapp/next/app/home/ChatWorkspace/HomeChatContext.tsx
@@ -18,6 +18,7 @@ export interface UseHomeChatResult {
   error: string | null;
   sendMessage: (text: string) => Promise<void>;
   clearMessages: () => void;
+  resetChat: () => void;
 }
 
 type HomeChatContextValue = UseHomeChatResult;
@@ -126,9 +127,19 @@ export function HomeChatProvider({ children }: { children: ReactNode }) {
     setError(null);
   };
 
+  /**
+   * resetChat - Full reset for New Chat button
+   * Clears messages, error, and sending state.
+   */
+  const resetChat = (): void => {
+    setMessages([]);
+    setError(null);
+    setSending(false);
+  };
+
   return (
     <HomeChatContext.Provider
-      value={{ messages, sending, error, sendMessage, clearMessages }}
+      value={{ messages, sending, error, sendMessage, clearMessages, resetChat }}
     >
       {children}
     </HomeChatContext.Provider>

--- a/rocketgpt_v3_full/webapp/next/app/home/ChatWorkspace/LeftSessionsPane.tsx
+++ b/rocketgpt_v3_full/webapp/next/app/home/ChatWorkspace/LeftSessionsPane.tsx
@@ -7,7 +7,7 @@ import { useHomeChat } from "./useHomeChat";
 export default function LeftSessionsPane() {
   const { groups, loading, error, activeSessionId, selectSession, isAuthenticated } =
     useHomeSessions();
-  const { clearMessages } = useHomeChat();
+  const { resetChat } = useHomeChat();
 
   return (
     <aside className="h-full bg-slate-950/60 border-r border-slate-900/80 flex flex-col">
@@ -23,7 +23,7 @@ export default function LeftSessionsPane() {
         </div>
         <button
           type="button"
-          onClick={clearMessages}
+          onClick={resetChat}
           className="inline-flex items-center rounded-full border border-emerald-500/70 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-200 hover:bg-emerald-500/20 focus:outline-none focus:ring-1 focus:ring-emerald-500"
         >
           <span className="mr-1 text-[13px] leading-none">＋</span>


### PR DESCRIPTION
## Summary

Critical Phase-1 UX fixes for demo-blocking issues.

## Fixes

| Issue | Fix |
|-------|-----|
| `/api/demo/chat` returns 500 | Now returns 200 with stub reply |
| New Chat button ineffective | Added `resetChat()` that clears messages, error, sending |
| Chat shows stale messages | `resetChat()` wired to New Chat button |

## Files Changed

- `app/api/demo/chat/route.ts` - Stub API (always 200)
- `app/home/ChatWorkspace/HomeChatContext.tsx` - Added `resetChat()`
- `app/home/ChatWorkspace/LeftSessionsPane.tsx` - Wired New button to `resetChat()`

## Verification

- [x] `pnpm lint` passes
- [ ] Chat starts empty in incognito
- [ ] New Chat clears transcript
- [ ] Sending message returns stub reply (no 500)

---
🤖 Generated with [Claude Code](https://claude.ai/code)