### PR TITLE
fix(auth): derive OAuth redirect URL from window.location.origin

### DIFF
--- a/rocketgpt_v3_full/webapp/next/app/login/page.tsx
+++ b/rocketgpt_v3_full/webapp/next/app/login/page.tsx
@@ -3,6 +3,17 @@
 import { useEffect, useMemo, useState } from 'react'
 import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 
+/**
+ * Get the site URL for OAuth redirects.
+ * Uses NEXT_PUBLIC_SITE_URL if set, otherwise derives from window.location.origin.
+ */
+function getSiteUrl(): string {
+  if (typeof window !== 'undefined') {
+    return process.env.NEXT_PUBLIC_SITE_URL || window.location.origin
+  }
+  return process.env.NEXT_PUBLIC_SITE_URL || ''
+}
+
 export default function LoginPage() {
   const [email, setEmail] = useState('')
   const [otpSent, setOtpSent] = useState(false)
@@ -12,9 +23,10 @@ export default function LoginPage() {
   const supabase = useMemo(() => getSupabaseBrowserClient(), [])
 
   async function sendOtp() {
+    const siteUrl = getSiteUrl()
     const { error } = await supabase.auth.signInWithOtp({
       email,
-      options: { emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?next=/account` },
+      options: { emailRedirectTo: `${siteUrl}/auth/callback?next=/account` },
     })
     if (error) alert(error.message)
     else setOtpSent(true)
@@ -31,9 +43,10 @@ export default function LoginPage() {
   }
 
   async function oauth(provider: 'google' | 'azure') {
+    const siteUrl = getSiteUrl()
     const { error } = await supabase.auth.signInWithOAuth({
       provider,
-      options: { redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?next=/account` },
+      options: { redirectTo: `${siteUrl}/auth/callback?next=/account` },
     })
     if (error) alert(error.message)
   }


### PR DESCRIPTION
## Problem
"Continue with Google" on https://rocketgpt.dev/login was failing because `NEXT_PUBLIC_SITE_URL` environment variable was not set in production.

The OAuth redirect URL was being constructed as:
```
undefined/auth/callback?next=/account
```

This caused Google/Supabase OAuth to fail with a malformed redirect URL.

## Solution
Added `getSiteUrl()` helper function that:
1. Returns `NEXT_PUBLIC_SITE_URL` if set (for explicit configuration)
2. Falls back to `window.location.origin` in browser context (automatic)

This ensures OAuth works regardless of whether the env var is configured.

## Files Changed
- `app/login/page.tsx` - Added `getSiteUrl()` helper, updated `sendOtp()` and `oauth()` functions

## Test Plan
- [ ] Deploy to Vercel
- [ ] Go to https://rocketgpt.dev/login
- [ ] Click "Continue with Google"
- [ ] Should redirect to Google OAuth
- [ ] After auth, should redirect back to /auth/callback then /account

Generated with Claude Code
