### PR TITLE
chore: add git guardrails for local replay + codex usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,15 @@ ci_logs/
 # Ignore Windows reserved device file accidentally created
 nul
 
+# ---- Python noise ----
+__pycache__/
+*.pyc
+
+# ---- Local replay artifacts ----
+apps/core-api/replay/evidence/
+
+# ---- Codex operational notes ----
+docs/ops/codex/
+
+# ---- Local tooling experiments ----
+tools/ops/runtime_unified_timeline.js


### PR DESCRIPTION
Purpose:
- Prevent local replay artifacts, __pycache__, and Codex ops notes from entering Git history
- Enforce safety without relying on human discipline

Impact:
- No runtime or governance behavior change
- Dev-only guardrail

Scope:
- .gitignore only