### PR TITLE
RGPT Phase-E3-F: deterministic snapshots + STRICT begin/end drift gate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,4 @@
 *.ps1  text eol=crlf
 *.cmd  text eol=crlf
 *.bat  text eol=crlf
+apps/core-api/replay/replay_runner.py text eol=lf


### PR DESCRIPTION
Purpose
- Deterministic snapshot file root (repo-root docs/ops/executions) independent of CWD
- STRICT begin/end snapshot drift gate with explicit mode override (CLI --mode)
- Optional test hook: RGPT_SNAPSHOT_TEST_SLEEP_MS

Proof
- STRICT drift injection results in DENIED + exit code 2 (PS-71), replay_result.json shows snapshot_drift_strict

Files
- apps/core-api/replay/replay_runner.py
- .gitattributes (force LF for replay_runner.py)

Notes
- Repo root derived via Path(__file__).resolve().parents[3]