### PR TITLE
D6: Add CATS governance monitor (CRPS, policy, containment, digest)

### DIFF
--- a/rocketgpt_v3_full/webapp/next/app/api/governance/containment-events/route.ts
+++ b/rocketgpt_v3_full/webapp/next/app/api/governance/containment-events/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { listContainmentEvents } from "@/lib/db/governanceRepo";
+import { isPrivilegedRead } from "@/lib/governance/auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+function toIso(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
+function redactForOperator(rows: any[]): any[] {
+  return rows.map((row) => ({
+    id: row.id,
+    run_id: row.run_id,
+    workflow_id: row.workflow_id,
+    crps_id: row.crps_id,
+    containment_level: row.containment_level,
+    explanation: row.explanation,
+    created_at: row.created_at,
+  }));
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const from = toIso(req.nextUrl.searchParams.get("from"));
+    const to = toIso(req.nextUrl.searchParams.get("to"));
+    const rows = await listContainmentEvents(from, to);
+    const data = isPrivilegedRead(req) ? rows : redactForOperator(rows);
+    return NextResponse.json({ items: data }, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to fetch containment events.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/rocketgpt_v3_full/webapp/next/app/api/governance/crps/route.ts
+++ b/rocketgpt_v3_full/webapp/next/app/api/governance/crps/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { listCrpsExecutions } from "@/lib/db/governanceRepo";
+import { isPrivilegedRead } from "@/lib/governance/auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+function toIso(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
+function redactForOperator(rows: any[]): any[] {
+  return rows.map((row) => ({
+    id: row.id,
+    run_id: row.run_id,
+    workflow_id: row.workflow_id,
+    crps_id: row.crps_id,
+    impact_score: row.impact_score,
+    reversibility_score: row.reversibility_score,
+    aggressiveness_score: row.aggressiveness_score,
+    confidence: row.confidence,
+    recommended_level: row.recommended_level,
+    risk_domains: row.risk_domains,
+    created_at: row.created_at,
+    explanation: "Detailed CRPS fields are restricted to admin/auditor roles.",
+  }));
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const from = toIso(req.nextUrl.searchParams.get("from"));
+    const to = toIso(req.nextUrl.searchParams.get("to"));
+    const rows = await listCrpsExecutions(from, to);
+    const data = isPrivilegedRead(req) ? rows : redactForOperator(rows);
+    return NextResponse.json({ items: data }, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to fetch CRPS records.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/rocketgpt_v3_full/webapp/next/app/api/governance/digests/route.ts
+++ b/rocketgpt_v3_full/webapp/next/app/api/governance/digests/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { listWeeklyDigests } from "@/lib/db/governanceRepo";
+import { isPrivilegedRead } from "@/lib/governance/auth";
+import { runWeeklyDigestJob } from "@/lib/governance/digest-job";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+export async function GET(req: NextRequest) {
+  try {
+    if (!isPrivilegedRead(req)) {
+      return NextResponse.json({ error: "Forbidden." }, { status: 403 });
+    }
+    await runWeeklyDigestJob(false);
+    const items = await listWeeklyDigests();
+    return NextResponse.json({ items }, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to fetch weekly digests.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/rocketgpt_v3_full/webapp/next/app/api/governance/foresight-tasks/route.ts
+++ b/rocketgpt_v3_full/webapp/next/app/api/governance/foresight-tasks/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { listForesightTasks } from "@/lib/db/governanceRepo";
+import { isPrivilegedRead } from "@/lib/governance/auth";
+import type { ForesightTaskStatus } from "@/lib/governance/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+function parseStatus(value: string | null): ForesightTaskStatus | undefined {
+  if (!value) return undefined;
+  if (value === "open" || value === "in_review" || value === "resolved") return value;
+  return undefined;
+}
+
+function redactForOperator(rows: any[]): any[] {
+  return rows.map((row) => ({
+    id: row.id,
+    crps_id: row.crps_id,
+    summary: row.summary,
+    status: row.status,
+    domain_queues: row.domain_queues,
+    created_at: row.created_at,
+    detail: "Restricted. Request admin/auditor role for full foresight details.",
+  }));
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const status = parseStatus(req.nextUrl.searchParams.get("status"));
+    const rows = await listForesightTasks(status);
+    const data = isPrivilegedRead(req) ? rows : redactForOperator(rows);
+    return NextResponse.json({ items: data }, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to fetch foresight tasks.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/rocketgpt_v3_full/webapp/next/app/api/governance/jobs/weekly-digest/route.ts
+++ b/rocketgpt_v3_full/webapp/next/app/api/governance/jobs/weekly-digest/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { isAdminWrite } from "@/lib/governance/auth";
+import { runWeeklyDigestJob } from "@/lib/governance/digest-job";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+export async function POST(req: NextRequest) {
+  try {
+    if (!isAdminWrite(req)) {
+      return NextResponse.json({ error: "Admin token required." }, { status: 401 });
+    }
+    const body = await req.json().catch(() => ({}));
+    const force = Boolean(body?.force);
+    const result = await runWeeklyDigestJob(force);
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to run weekly digest job.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/rocketgpt_v3_full/webapp/next/app/api/governance/policies/route.ts
+++ b/rocketgpt_v3_full/webapp/next/app/api/governance/policies/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { loadPolicyRules, upsertPolicyRule } from "@/lib/db/governanceRepo";
+import { isAdminWrite, isPrivilegedRead } from "@/lib/governance/auth";
+import type { GovernancePolicyRule } from "@/lib/governance/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+export async function GET(req: NextRequest) {
+  try {
+    if (!isPrivilegedRead(req)) {
+      return NextResponse.json({ error: "Forbidden." }, { status: 403 });
+    }
+    const items = await loadPolicyRules();
+    return NextResponse.json({ items }, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to list policy rules.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    if (!isAdminWrite(req)) {
+      return NextResponse.json({ error: "Admin token required." }, { status: 401 });
+    }
+
+    const body = await req.json().catch(() => null);
+    const incoming = body?.rule ?? body;
+    if (!incoming || typeof incoming !== "object") {
+      return NextResponse.json({ error: "Invalid policy payload." }, { status: 400 });
+    }
+
+    const rule: GovernancePolicyRule = {
+      id: String(incoming.id ?? "").trim(),
+      name: String(incoming.name ?? "").trim(),
+      enabled: Boolean(incoming.enabled),
+      priority: Number(incoming.priority ?? 0),
+      conditions: incoming.conditions ?? {},
+      action: incoming.action ?? { level: 1, explainTemplate: "Policy applied." },
+    };
+    if (!rule.id || !rule.name) {
+      return NextResponse.json({ error: "id and name are required." }, { status: 400 });
+    }
+
+    await upsertPolicyRule(rule);
+    return NextResponse.json({ ok: true, rule }, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to upsert policy rule.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/rocketgpt_v3_full/webapp/next/app/api/governance/post-run/route.ts
+++ b/rocketgpt_v3_full/webapp/next/app/api/governance/post-run/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { logGovernancePostRun } from "@/lib/governance/governance-service";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => null);
+    if (!body?.runId || !body?.workflowId || !body?.crpsId || !Array.isArray(body?.results)) {
+      return NextResponse.json(
+        { error: "runId, workflowId, crpsId, and results are required." },
+        { status: 400 }
+      );
+    }
+    await logGovernancePostRun({
+      runId: String(body.runId),
+      workflowId: String(body.workflowId),
+      crpsId: String(body.crpsId),
+      results: body.results,
+    });
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Governance post-run logging failed.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/rocketgpt_v3_full/webapp/next/app/api/governance/preflight/route.ts
+++ b/rocketgpt_v3_full/webapp/next/app/api/governance/preflight/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { evaluateGovernancePreflight } from "@/lib/governance/governance-service";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => null);
+    if (!body?.runId || !body?.workflowId || !Array.isArray(body?.nodes)) {
+      return NextResponse.json(
+        { error: "runId, workflowId, and nodes are required." },
+        { status: 400 }
+      );
+    }
+
+    const result = await evaluateGovernancePreflight({
+      runId: String(body.runId),
+      workflowId: String(body.workflowId),
+      nodes: body.nodes,
+      params: body.params ?? {},
+      actorId: body.actorId ?? null,
+      orgId: body.orgId ?? null,
+    });
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Governance preflight failed.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/rocketgpt_v3_full/webapp/next/app/super/governance/page.tsx
+++ b/rocketgpt_v3_full/webapp/next/app/super/governance/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type PolicyRule = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  priority: number;
+  action: { level: 1 | 2 | 3; explainTemplate: string };
+};
+
+export default function GovernanceAdminPage() {
+  const [policies, setPolicies] = useState<PolicyRule[]>([]);
+  const [events, setEvents] = useState<any[]>([]);
+  const [tasks, setTasks] = useState<any[]>([]);
+  const [digests, setDigests] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState<string | null>(null);
+  const [adminToken, setAdminToken] = useState("");
+
+  async function loadAll() {
+    setLoading(true);
+    setMessage(null);
+    try {
+      const commonHeaders = {
+        "x-governance-role": "admin",
+      };
+      const [policyRes, eventRes, taskRes, digestRes] = await Promise.all([
+        fetch("/api/governance/policies", { headers: commonHeaders }),
+        fetch("/api/governance/containment-events", { headers: commonHeaders }),
+        fetch("/api/governance/foresight-tasks?status=open", { headers: commonHeaders }),
+        fetch("/api/governance/digests", { headers: commonHeaders }),
+      ]);
+
+      const [policyJson, eventJson, taskJson, digestJson] = await Promise.all([
+        policyRes.json(),
+        eventRes.json(),
+        taskRes.json(),
+        digestRes.json(),
+      ]);
+      setPolicies(policyJson.items ?? []);
+      setEvents(eventJson.items ?? []);
+      setTasks(taskJson.items ?? []);
+      setDigests(digestJson.items ?? []);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Failed to load governance data.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadAll();
+  }, []);
+
+  async function togglePolicy(rule: PolicyRule) {
+    setMessage(null);
+    try {
+      const res = await fetch("/api/governance/policies", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-governance-role": "admin",
+          "x-admin-token": adminToken,
+        },
+        body: JSON.stringify({ rule: { ...rule, enabled: !rule.enabled } }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        throw new Error(json.error ?? "Failed to update policy.");
+      }
+      setMessage(`Updated policy ${rule.id}.`);
+      await loadAll();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Policy update failed.");
+    }
+  }
+
+  async function runDigestNow() {
+    setMessage(null);
+    try {
+      const res = await fetch("/api/governance/jobs/weekly-digest", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-governance-role": "admin",
+          "x-admin-token": adminToken,
+        },
+        body: JSON.stringify({ force: true }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        throw new Error(json.error ?? "Failed to run weekly digest job.");
+      }
+      setMessage(json.ran ? `Digest generated: ${json.digestId}` : json.reason ?? "Digest not due.");
+      await loadAll();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Digest trigger failed.");
+    }
+  }
+
+  return (
+    <div className="space-y-4 p-5">
+      <h1 className="text-2xl font-semibold">CATS Governance Monitor</h1>
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        Policies, L2/L3 interventions, foresight tasks, and weekly risk digests.
+      </p>
+
+      <div className="rounded border border-gray-200 p-3 dark:border-neutral-700">
+        <label className="text-sm">
+          Admin token
+          <input
+            value={adminToken}
+            onChange={(event) => setAdminToken(event.target.value)}
+            className="mt-1 w-full rounded border border-gray-300 px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+          />
+        </label>
+        <button
+          type="button"
+          onClick={() => void runDigestNow()}
+          className="mt-2 rounded border border-gray-300 px-3 py-1.5 text-sm dark:border-neutral-700"
+        >
+          Run Weekly Digest Now
+        </button>
+      </div>
+
+      {message ? (
+        <div className="rounded border border-sky-300 bg-sky-50 p-2 text-sm text-sky-800 dark:border-sky-900/70 dark:bg-sky-950/40 dark:text-sky-200">
+          {message}
+        </div>
+      ) : null}
+
+      {loading ? <div className="text-sm text-gray-600">Loading governance data...</div> : null}
+
+      <section className="rounded border border-gray-200 p-3 dark:border-neutral-700">
+        <h2 className="text-lg font-semibold">Policy Editor</h2>
+        <div className="mt-2 space-y-2">
+          {policies.map((rule) => (
+            <div key={rule.id} className="rounded border border-gray-200 p-2 dark:border-neutral-800">
+              <div className="text-sm font-semibold">{rule.name}</div>
+              <div className="text-xs text-gray-600 dark:text-gray-300">
+                {rule.id} · priority {rule.priority} · L{rule.action?.level}
+              </div>
+              <button
+                type="button"
+                onClick={() => void togglePolicy(rule)}
+                className="mt-2 rounded border border-gray-300 px-2 py-1 text-xs dark:border-neutral-700"
+              >
+                {rule.enabled ? "Disable" : "Enable"}
+              </button>
+            </div>
+          ))}
+          {policies.length === 0 ? <div className="text-sm text-gray-600">No policy rules found.</div> : null}
+        </div>
+      </section>
+
+      <section className="rounded border border-gray-200 p-3 dark:border-neutral-700">
+        <h2 className="text-lg font-semibold">L2/L3 Events</h2>
+        <div className="mt-2 space-y-2">
+          {events.slice(0, 20).map((event) => (
+            <div key={event.id} className="rounded border border-gray-200 p-2 text-sm dark:border-neutral-800">
+              <div className="font-semibold">
+                L{event.containment_level} · {event.workflow_id}
+              </div>
+              <div className="text-xs text-gray-600 dark:text-gray-300">{event.explanation}</div>
+            </div>
+          ))}
+          {events.length === 0 ? <div className="text-sm text-gray-600">No containment events yet.</div> : null}
+        </div>
+      </section>
+
+      <section className="rounded border border-gray-200 p-3 dark:border-neutral-700">
+        <h2 className="text-lg font-semibold">Foresight Tasks</h2>
+        <div className="mt-2 space-y-2">
+          {tasks.slice(0, 20).map((task) => (
+            <div key={task.id} className="rounded border border-gray-200 p-2 text-sm dark:border-neutral-800">
+              <div className="font-semibold">{task.summary}</div>
+              <div className="text-xs text-gray-600 dark:text-gray-300">
+                {task.status} · queues: {(task.domain_queues ?? []).join(", ")}
+              </div>
+            </div>
+          ))}
+          {tasks.length === 0 ? <div className="text-sm text-gray-600">No open foresight tasks.</div> : null}
+        </div>
+      </section>
+
+      <section className="rounded border border-gray-200 p-3 dark:border-neutral-700">
+        <h2 className="text-lg font-semibold">Weekly Digest Viewer</h2>
+        <div className="mt-2 space-y-2">
+          {digests.slice(0, 10).map((digest) => (
+            <div key={digest.id} className="rounded border border-gray-200 p-2 text-sm dark:border-neutral-800">
+              <div className="font-semibold">
+                {digest.week_start} to {digest.week_end}
+              </div>
+              <div className="text-xs text-gray-600 dark:text-gray-300">
+                Patterns: {digest.digest_payload?.topPatterns?.length ?? 0} · L2/L3 events:{" "}
+                {digest.digest_payload?.l2l3Events?.length ?? 0}
+              </div>
+            </div>
+          ))}
+          {digests.length === 0 ? <div className="text-sm text-gray-600">No digests published yet.</div> : null}
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/rocketgpt_v3_full/webapp/next/docs/governance/cats-governance-monitor.md
+++ b/rocketgpt_v3_full/webapp/next/docs/governance/cats-governance-monitor.md
@@ -1,0 +1,69 @@
+# CATS Governance Monitor
+
+## Overview
+The CATS Governance Monitor adds a centralized risk and containment layer on top of workflow execution.
+
+Core capabilities:
+- CRPS generation per execution (deterministic CAT Risk Pattern Signature)
+- Policy-based containment (L1/L2/L3)
+- Foresight task creation for L2/L3 events
+- Weekly digest generation (Mode C) with manual/event trigger support (Mode B)
+- Append-only governance ledger events
+
+## Architecture
+- `lib/governance/risk-scoring.ts`: deterministic CRPS computation
+- `lib/governance/policy-engine.ts`: rule matching + default policies
+- `lib/governance/containment-engine.ts`: containment decisions + simulation artifacts
+- `lib/governance/foresight-engine.ts`: foresight task templates
+- `lib/governance/digest-job.ts`: weekly aggregation + publication
+- `lib/governance/governance-service.ts`: orchestration of preflight/post-run operations
+- `lib/db/governanceRepo.ts`: persistence layer
+
+## Preflight/Post-run Integration
+- `lib/workflow-runner.ts` calls:
+  - `POST /api/governance/preflight` before execution
+  - `POST /api/governance/post-run` after execution
+
+Behavior:
+- L1: soft containment, execution allowed, simulation report required/logged
+- L2: approval checkpoint required, auto-exec disabled
+- L3: execution blocked, incident semantics enabled, foresight task created
+
+## Schema/Migration
+Migration file:
+- `supabase/migrations/20260302_cats_governance_monitor.sql`
+
+Created objects:
+- `governance.crps_executions`
+- `governance.crps_weekly_patterns`
+- `governance.policy_rules`
+- `governance.containment_events`
+- `governance.foresight_tasks`
+- `governance.weekly_digest_snapshots`
+- `governance.ledger_events` (append-only via triggers)
+
+## API Endpoints
+- `GET /api/governance/crps?from&to`
+- `GET /api/governance/containment-events?from&to`
+- `GET /api/governance/foresight-tasks?status=open|in_review|resolved`
+- `GET /api/governance/policies`
+- `POST /api/governance/policies`
+- `GET /api/governance/digests`
+- `POST /api/governance/jobs/weekly-digest` (manual trigger)
+- `POST /api/governance/preflight`
+- `POST /api/governance/post-run`
+
+## RBAC Model
+Headers used:
+- `x-governance-role`: `admin` | `auditor` | `operator`
+- `x-admin-token`: required for admin write operations, validated against `ADMIN_TOKEN`
+
+Read behavior:
+- `admin/auditor`: full details
+- `operator`: explanation-focused view with redacted details
+
+## Local Validation
+- Typecheck: `npm run typecheck`
+- Build: `NEXT_PUBLIC_CORE_API_BASE=http://localhost:8000 npm run build`
+- Governance unit tests: `npm run test:governance`
+

--- a/rocketgpt_v3_full/webapp/next/lib/db/governanceRepo.ts
+++ b/rocketgpt_v3_full/webapp/next/lib/db/governanceRepo.ts
@@ -1,0 +1,294 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import type {
+  ContainmentDecision,
+  ContainmentLevel,
+  CrpsSignature,
+  ForesightTaskStatus,
+  GovernanceLedgerEventType,
+  GovernancePolicyRule,
+  WeeklyDigestSnapshot,
+} from "@/lib/governance/types";
+import { DEFAULT_GOVERNANCE_RULES } from "@/lib/governance/policy-engine";
+
+const TABLES = {
+  crpsExecutions: "governance.crps_executions",
+  weeklyPatterns: "governance.crps_weekly_patterns",
+  policies: "governance.policy_rules",
+  containmentEvents: "governance.containment_events",
+  foresightTasks: "governance.foresight_tasks",
+  digests: "governance.weekly_digest_snapshots",
+  ledger: "governance.ledger_events",
+} as const;
+
+let supabaseAdminClient: SupabaseClient | null = null;
+
+function getSupabaseAdminClient(): SupabaseClient {
+  if (supabaseAdminClient) return supabaseAdminClient;
+  const url = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ??
+    process.env.SUPABASE_SERVICE_KEY ??
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) {
+    throw new Error("Missing Supabase server credentials.");
+  }
+  supabaseAdminClient = createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  return supabaseAdminClient;
+}
+
+function toIsoWeekStart(input: string | Date): string {
+  const date = new Date(input);
+  const day = date.getUTCDay();
+  const diff = (day + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - diff);
+  date.setUTCHours(0, 0, 0, 0);
+  return date.toISOString();
+}
+
+export async function insertCrpsExecution(
+  runId: string,
+  actorId: string | null,
+  orgId: string | null,
+  crps: CrpsSignature
+): Promise<void> {
+  const supabase = getSupabaseAdminClient();
+  const { error } = await supabase.from(TABLES.crpsExecutions).insert({
+    run_id: runId,
+    org_id: orgId,
+    actor_id: actorId,
+    crps_id: crps.crpsId,
+    workflow_id: crps.workflowId,
+    cats_involved: crps.catsInvolved,
+    params_fingerprint: crps.paramsFingerprint,
+    risk_domains: crps.riskDomains,
+    impact_score: crps.impactScore,
+    reversibility_score: crps.reversibilityScore,
+    aggressiveness_score: crps.aggressivenessScore,
+    override_rate: crps.overrideRate,
+    confidence: crps.confidence,
+    recommended_level: crps.recommendedLevel,
+    evidence_refs: crps.evidenceRefs,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function listCrpsExecutions(from?: string, to?: string): Promise<any[]> {
+  const supabase = getSupabaseAdminClient();
+  let query = supabase.from(TABLES.crpsExecutions).select("*").order("created_at", { ascending: false }).limit(500);
+  if (from) query = query.gte("created_at", from);
+  if (to) query = query.lte("created_at", to);
+  const { data, error } = await query;
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}
+
+export async function getRecentCrpsCount(crpsId: string, withinDays: number): Promise<number> {
+  const supabase = getSupabaseAdminClient();
+  const since = new Date(Date.now() - withinDays * 24 * 60 * 60 * 1000).toISOString();
+  const { count, error } = await supabase
+    .from(TABLES.crpsExecutions)
+    .select("id", { count: "exact", head: true })
+    .eq("crps_id", crpsId)
+    .gte("created_at", since);
+  if (error) throw new Error(error.message);
+  return count ?? 0;
+}
+
+export async function loadPolicyRules(): Promise<GovernancePolicyRule[]> {
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from(TABLES.policies)
+    .select("*")
+    .order("priority", { ascending: false });
+  if (error) {
+    if (error.message.toLowerCase().includes("relation")) {
+      return DEFAULT_GOVERNANCE_RULES;
+    }
+    throw new Error(error.message);
+  }
+  if (!data || data.length === 0) return DEFAULT_GOVERNANCE_RULES;
+  return data.map((row) => ({
+    id: row.id,
+    name: row.name,
+    enabled: !!row.enabled,
+    priority: Number(row.priority ?? 0),
+    conditions: row.conditions ?? {},
+    action: row.action ?? { level: 1, explainTemplate: "Fallback policy." },
+  }));
+}
+
+export async function upsertPolicyRule(rule: GovernancePolicyRule): Promise<void> {
+  const supabase = getSupabaseAdminClient();
+  const { error } = await supabase.from(TABLES.policies).upsert({
+    id: rule.id,
+    name: rule.name,
+    enabled: rule.enabled,
+    priority: rule.priority,
+    conditions: rule.conditions,
+    action: rule.action,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function insertContainmentEvent(input: {
+  runId: string;
+  workflowId: string;
+  crpsId: string;
+  level: ContainmentLevel;
+  decision: ContainmentDecision;
+  policyRuleId: string | null;
+  policyRuleName: string | null;
+}): Promise<{ id: string }> {
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from(TABLES.containmentEvents)
+    .insert({
+      run_id: input.runId,
+      workflow_id: input.workflowId,
+      crps_id: input.crpsId,
+      containment_level: input.level,
+      decision_payload: input.decision,
+      explanation: input.decision.explanation,
+      policy_rule_id: input.policyRuleId,
+      policy_rule_name: input.policyRuleName,
+    })
+    .select("id")
+    .single();
+  if (error) throw new Error(error.message);
+  return { id: data.id };
+}
+
+export async function listContainmentEvents(from?: string, to?: string): Promise<any[]> {
+  const supabase = getSupabaseAdminClient();
+  let query = supabase.from(TABLES.containmentEvents).select("*").order("created_at", { ascending: false }).limit(500);
+  if (from) query = query.gte("created_at", from);
+  if (to) query = query.lte("created_at", to);
+  const { data, error } = await query;
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}
+
+export async function insertForesightTask(input: {
+  crpsId: string;
+  summary: string;
+  whyItMatters: string;
+  scenarios: Record<string, unknown>;
+  stopConditions: string[];
+  mitigationIfLate: string;
+  recommendedPolicyChanges: string[];
+  recommendedCatPatches: string[];
+  domainQueues: string[];
+  status: ForesightTaskStatus;
+}): Promise<{ id: string }> {
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from(TABLES.foresightTasks)
+    .insert({
+      crps_id: input.crpsId,
+      summary: input.summary,
+      why_it_matters: input.whyItMatters,
+      scenarios: input.scenarios,
+      stop_conditions: input.stopConditions,
+      mitigation_if_late: input.mitigationIfLate,
+      recommended_policy_changes: input.recommendedPolicyChanges,
+      recommended_cat_patches: input.recommendedCatPatches,
+      domain_queues: input.domainQueues,
+      status: input.status,
+    })
+    .select("id")
+    .single();
+  if (error) throw new Error(error.message);
+  return { id: data.id };
+}
+
+export async function listForesightTasks(status?: ForesightTaskStatus): Promise<any[]> {
+  const supabase = getSupabaseAdminClient();
+  let query = supabase.from(TABLES.foresightTasks).select("*").order("created_at", { ascending: false }).limit(500);
+  if (status) query = query.eq("status", status);
+  const { data, error } = await query;
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}
+
+export async function insertWeeklyDigest(snapshot: WeeklyDigestSnapshot): Promise<void> {
+  const supabase = getSupabaseAdminClient();
+  const { error } = await supabase.from(TABLES.digests).insert({
+    id: snapshot.id,
+    week_start: snapshot.weekStart,
+    week_end: snapshot.weekEnd,
+    digest_payload: snapshot,
+    generated_at: snapshot.generatedAt,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function listWeeklyDigests(): Promise<any[]> {
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from(TABLES.digests)
+    .select("*")
+    .order("generated_at", { ascending: false })
+    .limit(52);
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}
+
+export async function upsertWeeklyPattern(input: {
+  weekStart: string;
+  crpsId: string;
+  workflowId: string;
+  riskDomains: string[];
+  count: number;
+}): Promise<void> {
+  const supabase = getSupabaseAdminClient();
+  const { error } = await supabase.from(TABLES.weeklyPatterns).upsert(
+    {
+      week_start: toIsoWeekStart(input.weekStart),
+      crps_id: input.crpsId,
+      workflow_id: input.workflowId,
+      risk_domains: input.riskDomains,
+      execution_count: input.count,
+    },
+    { onConflict: "week_start,crps_id" }
+  );
+  if (error) throw new Error(error.message);
+}
+
+export async function appendGovernanceLedgerEvent(input: {
+  eventType: GovernanceLedgerEventType;
+  runId?: string | null;
+  workflowId: string;
+  crpsId?: string | null;
+  payload: Record<string, unknown>;
+}): Promise<{ id: string }> {
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from(TABLES.ledger)
+    .insert({
+      event_type: input.eventType,
+      run_id: input.runId ?? null,
+      workflow_id: input.workflowId,
+      crps_id: input.crpsId ?? null,
+      payload: input.payload,
+    })
+    .select("id")
+    .single();
+  if (error) throw new Error(error.message);
+  return { id: data.id };
+}
+
+export async function getLastDigestGeneratedAt(): Promise<string | null> {
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from(TABLES.digests)
+    .select("generated_at")
+    .order("generated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return data?.generated_at ?? null;
+}
+

--- a/rocketgpt_v3_full/webapp/next/lib/governance/auth.ts
+++ b/rocketgpt_v3_full/webapp/next/lib/governance/auth.ts
@@ -1,0 +1,24 @@
+import { NextRequest } from "next/server";
+
+export type GovernanceRole = "admin" | "auditor" | "operator";
+
+export function getGovernanceRole(req: NextRequest): GovernanceRole {
+  const role = (req.headers.get("x-governance-role") || "").trim().toLowerCase();
+  if (role === "admin") return "admin";
+  if (role === "auditor") return "auditor";
+  return "operator";
+}
+
+export function isPrivilegedRead(req: NextRequest): boolean {
+  const role = getGovernanceRole(req);
+  if (role === "admin" || role === "auditor") return true;
+  return false;
+}
+
+export function isAdminWrite(req: NextRequest): boolean {
+  const role = getGovernanceRole(req);
+  if (role !== "admin") return false;
+  const token = req.headers.get("x-admin-token");
+  return !!token && !!process.env.ADMIN_TOKEN && token === process.env.ADMIN_TOKEN;
+}
+

--- a/rocketgpt_v3_full/webapp/next/lib/governance/containment-engine.ts
+++ b/rocketgpt_v3_full/webapp/next/lib/governance/containment-engine.ts
@@ -1,0 +1,63 @@
+import type {
+  ContainmentDecision,
+  CrpsSignature,
+  PolicyDecision,
+  SimulationReport,
+} from "./types";
+import type { WorkflowNode } from "../workflow-types";
+
+export function buildSimulationReport(
+  workflowId: string,
+  nodes: WorkflowNode[],
+  crps: CrpsSignature
+): SimulationReport {
+  const nodeNames = nodes.map((node) => node.name).slice(0, 3).join(", ");
+  const domains = crps.riskDomains.join(", ") || "general";
+  return {
+    horizons: {
+      d30: `30-day: Monitor initial effects for workflow ${workflowId} across ${domains}.`,
+      d90: `90-day: Validate control stability and drift for CATs ${nodeNames || "selected workflow nodes"}.`,
+      d365: `365-day: Audit long-term reversibility and policy compliance footprints.`,
+    },
+    secondOrderChecklist: [
+      "Could this workflow shift incentives toward unsafe shortcuts?",
+      "Could repeated execution increase legal/privacy exposure?",
+      "Could containment bypasses compound over time?",
+      "Are rollback and incident response paths tested?",
+    ],
+    alternatives: [
+      {
+        strategy: "aggressive",
+        expectedBenefit: "Fastest throughput and immediate optimization gains.",
+        riskTradeoff: "Higher blast radius and policy drift risk.",
+      },
+      {
+        strategy: "balanced",
+        expectedBenefit: "Moderate gains with staged rollout controls.",
+        riskTradeoff: "Requires monitoring overhead.",
+      },
+      {
+        strategy: "conservative",
+        expectedBenefit: "Lowest operational risk and highest reversibility.",
+        riskTradeoff: "Slower delivery and reduced immediate impact.",
+      },
+    ],
+  };
+}
+
+export function applyContainmentDecision(policyDecision: PolicyDecision): ContainmentDecision {
+  const action = policyDecision.action;
+  return {
+    level: action.level,
+    allowExecution: !action.blockExecution && !action.requireApprovalCheckpoint,
+    requireApprovalCheckpoint: action.requireApprovalCheckpoint ?? false,
+    disableAutoExec: action.disableAutoExec ?? false,
+    lockParameters: action.lockParameters ?? [],
+    requireSimulationReport: action.requireSimulationReport ?? false,
+    blockExecution: action.blockExecution ?? false,
+    openIncident: action.openIncident ?? false,
+    silent: action.silent ?? false,
+    explanation: policyDecision.explanation,
+  };
+}
+

--- a/rocketgpt_v3_full/webapp/next/lib/governance/digest-aggregate.ts
+++ b/rocketgpt_v3_full/webapp/next/lib/governance/digest-aggregate.ts
@@ -1,0 +1,81 @@
+import crypto from "crypto";
+
+import type { WeeklyDigestSnapshot } from "./types";
+
+function digestId(weekStart: string, weekEnd: string): string {
+  return crypto.createHash("sha256").update(`${weekStart}|${weekEnd}`).digest("hex");
+}
+
+export function aggregateWeeklyDigest(
+  crpsExecutions: any[],
+  containmentEvents: any[],
+  weekStart: string,
+  weekEnd: string
+): WeeklyDigestSnapshot {
+  const countMap = new Map<string, { count: number; workflowId: string; riskDomains: string[] }>();
+  for (const row of crpsExecutions) {
+    const current = countMap.get(row.crps_id);
+    if (!current) {
+      countMap.set(row.crps_id, {
+        count: 1,
+        workflowId: row.workflow_id,
+        riskDomains: row.risk_domains ?? [],
+      });
+    } else {
+      current.count += 1;
+    }
+  }
+
+  const topPatterns = Array.from(countMap.entries())
+    .map(([crpsId, value]) => ({
+      crpsId,
+      count: value.count,
+      trend: (value.count === 1 ? "new" : value.count >= 5 ? "up" : "flat") as "new" | "up" | "flat",
+      riskDomains: value.riskDomains as any,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 20);
+
+  const l2l3Events = containmentEvents
+    .filter((event) => Number(event.containment_level) >= 2)
+    .slice(0, 50)
+    .map((event) => ({
+      containmentEventId: event.id,
+      level: Number(event.containment_level) as 2 | 3,
+      workflowId: event.workflow_id,
+      crpsId: event.crps_id,
+      occurredAt: event.created_at,
+      explanation: event.explanation,
+    }));
+
+  const newPatterns = topPatterns.filter((pattern) => pattern.trend === "new").map((pattern) => pattern.crpsId);
+  const policyAdjustmentProposals: string[] = [];
+  const legalSecurityHits = topPatterns.filter((pattern) =>
+    pattern.riskDomains.some((domain) => domain === "legal" || domain === "security")
+  ).length;
+  if (legalSecurityHits >= 3) {
+    policyAdjustmentProposals.push(
+      "Increase approval requirements for legal/security patterns that appeared 3+ times this week."
+    );
+  }
+  if (l2l3Events.length >= 5) {
+    policyAdjustmentProposals.push(
+      "Review L2/L3 thresholds: high intervention volume suggests tuning impact/reversibility cutoffs."
+    );
+  }
+  if (policyAdjustmentProposals.length === 0) {
+    policyAdjustmentProposals.push("No urgent threshold changes recommended this week.");
+  }
+
+  return {
+    id: digestId(weekStart, weekEnd),
+    weekStart,
+    weekEnd,
+    topPatterns,
+    l2l3Events,
+    newPatterns,
+    policyAdjustmentProposals,
+    generatedAt: new Date().toISOString(),
+  };
+}
+

--- a/rocketgpt_v3_full/webapp/next/lib/governance/digest-job.ts
+++ b/rocketgpt_v3_full/webapp/next/lib/governance/digest-job.ts
@@ -1,0 +1,86 @@
+import {
+  appendGovernanceLedgerEvent,
+  getLastDigestGeneratedAt,
+  insertWeeklyDigest,
+  listContainmentEvents,
+  listCrpsExecutions,
+  upsertWeeklyPattern,
+} from "@/lib/db/governanceRepo";
+import { aggregateWeeklyDigest } from "@/lib/governance/digest-aggregate";
+
+function weekRange(now = new Date()): { weekStart: string; weekEnd: string } {
+  const end = new Date(now);
+  end.setUTCHours(23, 59, 59, 999);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 6);
+  start.setUTCHours(0, 0, 0, 0);
+  return { weekStart: start.toISOString(), weekEnd: end.toISOString() };
+}
+
+
+function parseIntEnv(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) return fallback;
+  return parsed;
+}
+
+function scheduledTimeThisWeek(now = new Date()): Date {
+  const day = parseIntEnv(process.env.GOV_WEEKLY_DIGEST_DAY, 0); // Sunday default
+  const hour = parseIntEnv(process.env.GOV_WEEKLY_DIGEST_HOUR, 9);
+  const minute = parseIntEnv(process.env.GOV_WEEKLY_DIGEST_MINUTE, 0);
+  const d = new Date(now);
+  const currentDay = d.getDay();
+  const diff = day - currentDay;
+  d.setDate(d.getDate() + diff);
+  d.setHours(hour, minute, 0, 0);
+  return d;
+}
+
+function isDue(lastGeneratedAt: string | null, now = new Date()): boolean {
+  const schedule = scheduledTimeThisWeek(now);
+  if (now.getTime() < schedule.getTime()) return false;
+  if (!lastGeneratedAt) return true;
+  const last = new Date(lastGeneratedAt);
+  return last.getTime() < schedule.getTime();
+}
+
+export async function runWeeklyDigestJob(force = false): Promise<{
+  ran: boolean;
+  digestId: string | null;
+  reason?: string;
+}> {
+  const lastGeneratedAt = await getLastDigestGeneratedAt();
+  if (!force && !isDue(lastGeneratedAt)) {
+    return { ran: false, digestId: null, reason: "Not due yet." };
+  }
+
+  const { weekStart, weekEnd } = weekRange();
+  const [crpsExecutions, containmentEvents] = await Promise.all([
+    listCrpsExecutions(weekStart, weekEnd),
+    listContainmentEvents(weekStart, weekEnd),
+  ]);
+
+  const snapshot = aggregateWeeklyDigest(crpsExecutions, containmentEvents, weekStart, weekEnd);
+  await insertWeeklyDigest(snapshot);
+
+  for (const pattern of snapshot.topPatterns) {
+    const row = crpsExecutions.find((entry) => entry.crps_id === pattern.crpsId);
+    await upsertWeeklyPattern({
+      weekStart,
+      crpsId: pattern.crpsId,
+      workflowId: row?.workflow_id ?? "unknown",
+      riskDomains: pattern.riskDomains,
+      count: pattern.count,
+    });
+  }
+
+  await appendGovernanceLedgerEvent({
+    eventType: "weekly_digest_published",
+    workflowId: "governance.weekly_digest",
+    crpsId: null,
+    payload: { digestId: snapshot.id, weekStart, weekEnd, topPatterns: snapshot.topPatterns.length },
+  });
+
+  return { ran: true, digestId: snapshot.id };
+}

--- a/rocketgpt_v3_full/webapp/next/lib/governance/foresight-engine.ts
+++ b/rocketgpt_v3_full/webapp/next/lib/governance/foresight-engine.ts
@@ -1,0 +1,43 @@
+import type { ContainmentDecision, CrpsSignature, ForesightTask, RiskDomain } from "./types";
+
+function domainQueues(domains: RiskDomain[]): RiskDomain[] {
+  if (domains.length === 0) return ["security"];
+  return Array.from(new Set(domains));
+}
+
+export function buildForesightTask(
+  crps: CrpsSignature,
+  containment: ContainmentDecision
+): Omit<ForesightTask, "id" | "createdAt"> {
+  const domains = domainQueues(crps.riskDomains);
+  return {
+    crpsId: crps.crpsId,
+    summary: `Containment L${containment.level} triggered for workflow ${crps.workflowId}.`,
+    whyItMatters:
+      `Impact score ${crps.impactScore}, reversibility ${crps.reversibilityScore}, and domains ` +
+      `${domains.join(", ")} indicate elevated governance risk.`,
+    scenarios: {
+      best: "Containment controls hold, workflow is revised, and risk drops in next run.",
+      likely: "Workflow pauses for approval/simulation updates before controlled restart.",
+      worst: "Unauthorized bypass causes high-impact irreversible outcomes requiring incident response.",
+    },
+    stopConditions: [
+      "Unexpected side effects outside approved domains.",
+      "Manual override rate exceeds policy threshold.",
+      "Simulation report missing or stale.",
+    ],
+    mitigationIfLate:
+      "Force emergency brake, snapshot execution context, and route to manual incident review.",
+    recommendedPolicyChanges: [
+      "Tighten thresholds for high-frequency CRPS patterns.",
+      "Increase approval requirements for multi-domain workflows.",
+    ],
+    recommendedCatPatches: [
+      "Add reversible mode toggles to high-impact CATs.",
+      "Restrict workflow_dispatch scopes with explicit allow-lists.",
+    ],
+    domainQueues: domains,
+    status: "open",
+  };
+}
+

--- a/rocketgpt_v3_full/webapp/next/lib/governance/governance-service.ts
+++ b/rocketgpt_v3_full/webapp/next/lib/governance/governance-service.ts
@@ -1,0 +1,164 @@
+import {
+  appendGovernanceLedgerEvent,
+  getRecentCrpsCount,
+  insertContainmentEvent,
+  insertCrpsExecution,
+  insertForesightTask,
+  loadPolicyRules,
+} from "@/lib/db/governanceRepo";
+import { submitApproval } from "@/lib/db/approvalsRepo";
+import { applyContainmentDecision, buildSimulationReport } from "@/lib/governance/containment-engine";
+import { buildForesightTask } from "@/lib/governance/foresight-engine";
+import { evaluatePolicyRules } from "@/lib/governance/policy-engine";
+import { computeCrpsSignature } from "@/lib/governance/risk-scoring";
+import type {
+  GovernancePostRunInput,
+  GovernancePreflightInput,
+  GovernancePreflightResult,
+} from "@/lib/governance/types";
+
+function hasRedLine(crps: { impactScore: number; reversibilityScore: number; riskDomains: string[] }): boolean {
+  return (
+    (crps.impactScore >= 90 && crps.reversibilityScore <= 20) ||
+    (crps.riskDomains.includes("legal") && crps.riskDomains.includes("security") && crps.impactScore >= 80)
+  );
+}
+
+export async function evaluateGovernancePreflight(
+  input: GovernancePreflightInput
+): Promise<GovernancePreflightResult> {
+  const crps = computeCrpsSignature({
+    workflowId: input.workflowId,
+    nodes: input.nodes,
+    params: input.params,
+    overrideRate: 0,
+    evidenceRefs: [],
+  });
+
+  await insertCrpsExecution(input.runId, input.actorId ?? null, input.orgId ?? null, crps);
+
+  const repeatCount = await getRecentCrpsCount(crps.crpsId, 30);
+  const redLineMatch = hasRedLine(crps);
+  const approvalsMissing = crps.recommendedLevel >= 2;
+
+  let simulationReport = null;
+  try {
+    simulationReport = buildSimulationReport(input.workflowId, input.nodes, crps);
+  } catch {
+    simulationReport = null;
+  }
+
+  const policyRules = await loadPolicyRules();
+  const policyDecision = evaluatePolicyRules(policyRules, crps, {
+    repeatCount,
+    redLineMatch,
+    approvalsMissing,
+    simulationMissing: simulationReport === null,
+  });
+  const containment = applyContainmentDecision(policyDecision);
+
+  const containmentEvent = await insertContainmentEvent({
+    runId: input.runId,
+    workflowId: input.workflowId,
+    crpsId: crps.crpsId,
+    level: containment.level,
+    decision: containment,
+    policyRuleId: policyDecision.matchedRuleId,
+    policyRuleName: policyDecision.matchedRuleName,
+  });
+
+  const riskLedger = await appendGovernanceLedgerEvent({
+    eventType: "risk_eval",
+    runId: input.runId,
+    workflowId: input.workflowId,
+    crpsId: crps.crpsId,
+    payload: { crps, repeatCount, redLineMatch, containmentLevel: containment.level },
+  });
+
+  await appendGovernanceLedgerEvent({
+    eventType: "containment_applied",
+    runId: input.runId,
+    workflowId: input.workflowId,
+    crpsId: crps.crpsId,
+    payload: {
+      containmentEventId: containmentEvent.id,
+      policyDecision,
+      containment,
+      evidenceRefs: [riskLedger.id],
+    },
+  });
+
+  if (containment.level >= 2) {
+    const approval = await submitApproval({
+      request_type: "governance.containment",
+      request_title: `Governance L${containment.level} checkpoint: ${input.workflowId}`,
+      payload: {
+        runId: input.runId,
+        workflowId: input.workflowId,
+        crpsId: crps.crpsId,
+        level: containment.level,
+        explanation: containment.explanation,
+      },
+      priority: containment.level >= 3 ? "critical" : "high",
+      risk_level: containment.level >= 3 ? "high" : "medium",
+      requested_by: "governance-monitor",
+    });
+    await appendGovernanceLedgerEvent({
+      eventType: "containment_applied",
+      runId: input.runId,
+      workflowId: input.workflowId,
+      crpsId: crps.crpsId,
+      payload: {
+        approvalCheckpointId: approval.id,
+        containmentLevel: containment.level,
+      },
+    });
+
+    const foresightTask = buildForesightTask(crps, containment);
+    const created = await insertForesightTask({
+      crpsId: foresightTask.crpsId,
+      summary: foresightTask.summary,
+      whyItMatters: foresightTask.whyItMatters,
+      scenarios: foresightTask.scenarios as Record<string, unknown>,
+      stopConditions: foresightTask.stopConditions,
+      mitigationIfLate: foresightTask.mitigationIfLate,
+      recommendedPolicyChanges: foresightTask.recommendedPolicyChanges,
+      recommendedCatPatches: foresightTask.recommendedCatPatches,
+      domainQueues: foresightTask.domainQueues,
+      status: foresightTask.status,
+    });
+    await appendGovernanceLedgerEvent({
+      eventType: "foresight_task_created",
+      runId: input.runId,
+      workflowId: input.workflowId,
+      crpsId: crps.crpsId,
+      payload: { foresightTaskId: created.id, summary: foresightTask.summary },
+    });
+  }
+
+  return {
+    crps,
+    policyDecision,
+    containment,
+    simulationReport,
+  };
+}
+
+export async function logGovernancePostRun(input: GovernancePostRunInput): Promise<void> {
+  const successCount = input.results.filter((result) => result.status === "success").length;
+  const failedCount = input.results.filter((result) => result.status === "failed").length;
+  await appendGovernanceLedgerEvent({
+    eventType: "risk_eval",
+    runId: input.runId,
+    workflowId: input.workflowId,
+    crpsId: input.crpsId,
+    payload: {
+      phase: "post_run",
+      resultSummary: {
+        total: input.results.length,
+        successCount,
+        failedCount,
+      },
+    },
+  });
+}

--- a/rocketgpt_v3_full/webapp/next/lib/governance/policy-engine.ts
+++ b/rocketgpt_v3_full/webapp/next/lib/governance/policy-engine.ts
@@ -1,0 +1,181 @@
+import type {
+  ContainmentLevel,
+  CrpsSignature,
+  GovernancePolicyAction,
+  GovernancePolicyRule,
+  PolicyContext,
+  PolicyDecision,
+} from "./types";
+
+function actionForLevel(level: ContainmentLevel): GovernancePolicyAction {
+  if (level === 3) {
+    return {
+      level: 3,
+      explainTemplate: "Emergency containment activated.",
+      lockParameters: ["*"],
+      disableAutoExec: true,
+      requireApprovalCheckpoint: true,
+      requireSimulationReport: true,
+      blockExecution: true,
+      openIncident: true,
+      silent: false,
+    };
+  }
+  if (level === 2) {
+    return {
+      level: 2,
+      explainTemplate: "Hard containment applied. Approval checkpoint required.",
+      lockParameters: ["aggressiveMode", "autoExecute", "maxBudget"],
+      disableAutoExec: true,
+      requireApprovalCheckpoint: true,
+      requireSimulationReport: true,
+      blockExecution: false,
+      openIncident: false,
+      silent: false,
+    };
+  }
+  return {
+    level: 1,
+    explainTemplate: "Soft containment applied to rebalance execution.",
+    disableAutoExec: false,
+    requireApprovalCheckpoint: false,
+    requireSimulationReport: true,
+    blockExecution: false,
+    openIncident: false,
+    silent: true,
+  };
+}
+
+function renderTemplate(template: string, crps: CrpsSignature): string {
+  return template
+    .replaceAll("{impactScore}", String(crps.impactScore))
+    .replaceAll("{reversibilityScore}", String(crps.reversibilityScore))
+    .replaceAll("{aggressivenessScore}", String(crps.aggressivenessScore))
+    .replaceAll("{domains}", crps.riskDomains.join(", ") || "none");
+}
+
+function matchesRule(rule: GovernancePolicyRule, crps: CrpsSignature, context: PolicyContext): boolean {
+  const c = rule.conditions;
+  if (c.impactScoreGte !== undefined && crps.impactScore < c.impactScoreGte) return false;
+  if (c.reversibilityScoreLte !== undefined && crps.reversibilityScore > c.reversibilityScoreLte) return false;
+  if (c.aggressivenessScoreGte !== undefined && crps.aggressivenessScore < c.aggressivenessScoreGte) return false;
+  if (c.overrideRateGte !== undefined && crps.overrideRate < c.overrideRateGte) return false;
+  if (c.confidenceGte !== undefined && crps.confidence < c.confidenceGte) return false;
+  if (c.repeatCountGte !== undefined && context.repeatCount < c.repeatCountGte) return false;
+  if (c.redLineMatch !== undefined && context.redLineMatch !== c.redLineMatch) return false;
+  if (c.approvalsMissing !== undefined && context.approvalsMissing !== c.approvalsMissing) return false;
+  if (c.simulationMissing !== undefined && context.simulationMissing !== c.simulationMissing) return false;
+  if (c.domainsIncludeAny?.length) {
+    if (!c.domainsIncludeAny.some((domain) => crps.riskDomains.includes(domain))) return false;
+  }
+  if (c.domainsIncludeAll?.length) {
+    if (!c.domainsIncludeAll.every((domain) => crps.riskDomains.includes(domain))) return false;
+  }
+  return true;
+}
+
+export function evaluatePolicyRules(
+  rules: GovernancePolicyRule[],
+  crps: CrpsSignature,
+  context: PolicyContext
+): PolicyDecision {
+  const sorted = rules
+    .filter((rule) => rule.enabled)
+    .slice()
+    .sort((a, b) => b.priority - a.priority);
+
+  for (const rule of sorted) {
+    if (!matchesRule(rule, crps, context)) continue;
+    return {
+      matchedRuleId: rule.id,
+      matchedRuleName: rule.name,
+      containmentLevel: rule.action.level,
+      explanation: renderTemplate(rule.action.explainTemplate, crps),
+      action: rule.action,
+    };
+  }
+
+  const fallback = actionForLevel(crps.recommendedLevel);
+  return {
+    matchedRuleId: null,
+    matchedRuleName: null,
+    containmentLevel: crps.recommendedLevel,
+    explanation: renderTemplate("Default policy applied for risk score {impactScore}.", crps),
+    action: fallback,
+  };
+}
+
+export const DEFAULT_GOVERNANCE_RULES: GovernancePolicyRule[] = [
+  {
+    id: "default-l3-high-impact-low-reversibility",
+    name: "L3: High impact and low reversibility",
+    enabled: true,
+    priority: 100,
+    conditions: {
+      impactScoreGte: 85,
+      reversibilityScoreLte: 30,
+    },
+    action: {
+      ...actionForLevel(3),
+      explainTemplate:
+        "Execution blocked: impact {impactScore} with reversibility {reversibilityScore} crossed emergency threshold.",
+    },
+  },
+  {
+    id: "default-l3-redline",
+    name: "L3: Red-line match",
+    enabled: true,
+    priority: 95,
+    conditions: {
+      redLineMatch: true,
+    },
+    action: {
+      ...actionForLevel(3),
+      explainTemplate: "Execution blocked due to red-line policy match in domains: {domains}.",
+    },
+  },
+  {
+    id: "default-l2-missing-approvals",
+    name: "L2: High impact with approvals missing",
+    enabled: true,
+    priority: 80,
+    conditions: {
+      impactScoreGte: 70,
+      approvalsMissing: true,
+    },
+    action: {
+      ...actionForLevel(2),
+      explainTemplate:
+        "Approval checkpoint required: impact {impactScore} is high and required approvals are missing.",
+    },
+  },
+  {
+    id: "default-l2-legal-security-confidence",
+    name: "L2: Legal/security domain with high confidence",
+    enabled: true,
+    priority: 70,
+    conditions: {
+      domainsIncludeAny: ["legal", "security"],
+      confidenceGte: 0.7,
+    },
+    action: {
+      ...actionForLevel(2),
+      explainTemplate:
+        "Approval checkpoint required for sensitive domains ({domains}) with confidence {impactScore}.",
+    },
+  },
+  {
+    id: "default-l1-baseline",
+    name: "L1: Baseline containment",
+    enabled: true,
+    priority: 10,
+    conditions: {
+      impactScoreGte: 50,
+    },
+    action: {
+      ...actionForLevel(1),
+      explainTemplate: "Soft containment applied for medium/high risk impact {impactScore}.",
+    },
+  },
+];
+

--- a/rocketgpt_v3_full/webapp/next/lib/governance/redaction.ts
+++ b/rocketgpt_v3_full/webapp/next/lib/governance/redaction.ts
@@ -1,0 +1,51 @@
+import crypto from "crypto";
+
+const SECRET_KEY_PATTERNS = [
+  /pass(word)?/i,
+  /secret/i,
+  /token/i,
+  /api[_-]?key/i,
+  /private[_-]?key/i,
+  /bearer/i,
+  /auth/i,
+  /credential/i,
+];
+
+function isSecretKey(key: string): boolean {
+  return SECRET_KEY_PATTERNS.some((pattern) => pattern.test(key));
+}
+
+function normalizeValue(input: unknown): unknown {
+  if (input === null || typeof input !== "object") return input;
+  if (Array.isArray(input)) return input.map((value) => normalizeValue(value));
+
+  const src = input as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  const keys = Object.keys(src).sort();
+  for (const key of keys) {
+    if (isSecretKey(key)) {
+      out[key] = "[REDACTED]";
+    } else {
+      out[key] = normalizeValue(src[key]);
+    }
+  }
+  return out;
+}
+
+export function redactSecrets(input: unknown): unknown {
+  return normalizeValue(input);
+}
+
+function stableStringify(input: unknown): string {
+  return JSON.stringify(normalizeValue(input));
+}
+
+export function sha256Hex(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+export function createParamsFingerprint(params: Record<string, unknown> | undefined): string {
+  const normalized = params ?? {};
+  return sha256Hex(stableStringify(normalized));
+}
+

--- a/rocketgpt_v3_full/webapp/next/lib/governance/risk-scoring.ts
+++ b/rocketgpt_v3_full/webapp/next/lib/governance/risk-scoring.ts
@@ -1,0 +1,129 @@
+import type { RiskDomain, RiskScoringInput, CrpsSignature, CrpsCat, ContainmentLevel } from "./types";
+import { createParamsFingerprint, sha256Hex } from "./redaction";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function deriveDomains(input: RiskScoringInput): RiskDomain[] {
+  const domains = new Set<RiskDomain>();
+  for (const node of input.nodes) {
+    if (node.allowed_side_effects.includes("workflow_dispatch")) {
+      domains.add("security");
+      domains.add("financial");
+      domains.add("safety");
+      domains.add("workforce");
+    }
+    if (node.allowed_side_effects.includes("ledger_write")) {
+      domains.add("legal");
+      domains.add("financial");
+      domains.add("privacy");
+    }
+    if (node.allowed_side_effects.includes("read_only")) {
+      domains.add("privacy");
+    }
+    const text = `${node.name} ${node.purpose}`.toLowerCase();
+    if (/emission|climate|energy|waste|water|environment/.test(text)) domains.add("env");
+    if (/legal|compliance|contract|regulat/.test(text)) domains.add("legal");
+    if (/security|auth|vulnerability|exploit/.test(text)) domains.add("security");
+    if (/pay|pricing|revenue|cost|budget|invoice/.test(text)) domains.add("financial");
+    if (/hiring|employee|staff|workforce|hr/.test(text)) domains.add("workforce");
+    if (/privacy|pii|consent|data/.test(text)) domains.add("privacy");
+    if (/safety|harm|danger|incident/.test(text)) domains.add("safety");
+  }
+  return Array.from(domains).sort() as RiskDomain[];
+}
+
+function calculateImpact(input: RiskScoringInput, domains: RiskDomain[]): number {
+  let base = 25;
+  for (const node of input.nodes) {
+    if (node.allowed_side_effects.includes("workflow_dispatch")) base += 30;
+    if (node.allowed_side_effects.includes("ledger_write")) base += 20;
+    if (node.allowed_side_effects.includes("read_only")) base += 5;
+    if (node.requires_approval) base += 8;
+    if (node.passport_required) base += 5;
+  }
+  base += domains.length * 3;
+  return clamp(Math.round(base / Math.max(1, input.nodes.length)), 0, 100);
+}
+
+function calculateReversibility(input: RiskScoringInput): number {
+  let score = 90;
+  for (const node of input.nodes) {
+    if (node.allowed_side_effects.includes("workflow_dispatch")) score -= 35;
+    if (node.allowed_side_effects.includes("ledger_write")) score -= 20;
+    if (node.allowed_side_effects.includes("read_only")) score -= 5;
+  }
+  return clamp(score, 0, 100);
+}
+
+function calculateAggressiveness(input: RiskScoringInput): number {
+  let score = 20;
+  for (const node of input.nodes) {
+    const text = `${node.name} ${node.purpose} ${node.selection_reason}`.toLowerCase();
+    if (/maximize|optimi[sz]e|aggressive|extract|speed|growth|dominat/.test(text)) score += 20;
+    if (/balanced|safe|compliance|conservative|guard/.test(text)) score -= 10;
+    if (node.allowed_side_effects.includes("workflow_dispatch")) score += 12;
+  }
+  return clamp(Math.round(score / Math.max(1, input.nodes.length)), 0, 100);
+}
+
+function calculateConfidence(input: RiskScoringInput, domains: RiskDomain[]): number {
+  const base = 0.55 + Math.min(0.25, domains.length * 0.03) + Math.min(0.15, input.nodes.length * 0.02);
+  return Math.round(clamp(base, 0, 1) * 100) / 100;
+}
+
+function recommendedLevelFromScores(
+  impactScore: number,
+  reversibilityScore: number,
+  aggressivenessScore: number
+): ContainmentLevel {
+  if (impactScore >= 85 && reversibilityScore <= 30) return 3;
+  if (impactScore >= 70 || aggressivenessScore >= 65) return 2;
+  if (impactScore >= 50) return 1;
+  return 1;
+}
+
+export function computeCrpsSignature(input: RiskScoringInput): CrpsSignature {
+  const catsInvolved: CrpsCat[] = input.nodes
+    .map((node) => ({
+      catId: node.cat_id,
+      version: "unknown",
+    }))
+    .sort((a, b) => `${a.catId}:${a.version}`.localeCompare(`${b.catId}:${b.version}`));
+
+  const paramsFingerprint = createParamsFingerprint(input.params);
+  const riskDomains = deriveDomains(input);
+  const impactScore = calculateImpact(input, riskDomains);
+  const reversibilityScore = calculateReversibility(input);
+  const aggressivenessScore = calculateAggressiveness(input);
+  const overrideRate = clamp(input.overrideRate ?? 0, 0, 100);
+  const confidence = calculateConfidence(input, riskDomains);
+  const recommendedLevel = recommendedLevelFromScores(
+    impactScore,
+    reversibilityScore,
+    aggressivenessScore
+  );
+  const evidenceRefs = input.evidenceRefs ?? [];
+
+  const sortedCats = catsInvolved.map((cat) => `${cat.catId}@${cat.version}`).join("|");
+  const crpsId = sha256Hex(
+    `${input.workflowId}|${sortedCats}|${paramsFingerprint}|${riskDomains.slice().sort().join(",")}`
+  );
+
+  return {
+    crpsId,
+    workflowId: input.workflowId,
+    catsInvolved,
+    paramsFingerprint,
+    riskDomains,
+    impactScore,
+    reversibilityScore,
+    aggressivenessScore,
+    overrideRate,
+    confidence,
+    recommendedLevel,
+    evidenceRefs,
+  };
+}
+

--- a/rocketgpt_v3_full/webapp/next/lib/governance/types.ts
+++ b/rocketgpt_v3_full/webapp/next/lib/governance/types.ts
@@ -1,0 +1,203 @@
+import type { WorkflowNode, WorkflowStepResult } from "../workflow-types";
+
+export type RiskDomain =
+  | "env"
+  | "legal"
+  | "security"
+  | "financial"
+  | "workforce"
+  | "privacy"
+  | "safety";
+
+export type ContainmentLevel = 1 | 2 | 3;
+
+export type CrpsCat = {
+  catId: string;
+  version: string;
+};
+
+export type CrpsSignature = {
+  crpsId: string;
+  workflowId: string;
+  catsInvolved: CrpsCat[];
+  paramsFingerprint: string;
+  riskDomains: RiskDomain[];
+  impactScore: number;
+  reversibilityScore: number;
+  aggressivenessScore: number;
+  overrideRate: number;
+  confidence: number;
+  recommendedLevel: ContainmentLevel;
+  evidenceRefs: string[];
+};
+
+export type RiskScoringInput = {
+  workflowId: string;
+  nodes: WorkflowNode[];
+  params?: Record<string, unknown>;
+  overrideRate?: number;
+  evidenceRefs?: string[];
+};
+
+export type GovernancePolicyCondition = {
+  impactScoreGte?: number;
+  reversibilityScoreLte?: number;
+  aggressivenessScoreGte?: number;
+  overrideRateGte?: number;
+  confidenceGte?: number;
+  domainsIncludeAny?: RiskDomain[];
+  domainsIncludeAll?: RiskDomain[];
+  repeatCountGte?: number;
+  redLineMatch?: boolean;
+  approvalsMissing?: boolean;
+  simulationMissing?: boolean;
+};
+
+export type GovernancePolicyAction = {
+  level: ContainmentLevel;
+  explainTemplate: string;
+  lockParameters?: string[];
+  disableAutoExec?: boolean;
+  requireApprovalCheckpoint?: boolean;
+  requireSimulationReport?: boolean;
+  blockExecution?: boolean;
+  openIncident?: boolean;
+  silent?: boolean;
+};
+
+export type GovernancePolicyRule = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  priority: number;
+  conditions: GovernancePolicyCondition;
+  action: GovernancePolicyAction;
+};
+
+export type PolicyContext = {
+  repeatCount: number;
+  redLineMatch: boolean;
+  approvalsMissing: boolean;
+  simulationMissing: boolean;
+};
+
+export type PolicyDecision = {
+  matchedRuleId: string | null;
+  matchedRuleName: string | null;
+  containmentLevel: ContainmentLevel;
+  explanation: string;
+  action: GovernancePolicyAction;
+};
+
+export type ContainmentDecision = {
+  level: ContainmentLevel;
+  allowExecution: boolean;
+  requireApprovalCheckpoint: boolean;
+  disableAutoExec: boolean;
+  lockParameters: string[];
+  requireSimulationReport: boolean;
+  blockExecution: boolean;
+  openIncident: boolean;
+  silent: boolean;
+  explanation: string;
+};
+
+export type SimulationAlternative = {
+  strategy: "aggressive" | "balanced" | "conservative";
+  expectedBenefit: string;
+  riskTradeoff: string;
+};
+
+export type SimulationReport = {
+  horizons: {
+    d30: string;
+    d90: string;
+    d365: string;
+  };
+  secondOrderChecklist: string[];
+  alternatives: SimulationAlternative[];
+};
+
+export type ForesightTaskStatus = "open" | "in_review" | "resolved";
+
+export type ForesightTask = {
+  id: string;
+  crpsId: string;
+  summary: string;
+  whyItMatters: string;
+  scenarios: {
+    best: string;
+    likely: string;
+    worst: string;
+  };
+  stopConditions: string[];
+  mitigationIfLate: string;
+  recommendedPolicyChanges: string[];
+  recommendedCatPatches: string[];
+  domainQueues: RiskDomain[];
+  status: ForesightTaskStatus;
+  createdAt: string;
+};
+
+export type WeeklyDigestSnapshot = {
+  id: string;
+  weekStart: string;
+  weekEnd: string;
+  topPatterns: Array<{
+    crpsId: string;
+    count: number;
+    trend: "new" | "up" | "flat";
+    riskDomains: RiskDomain[];
+  }>;
+  l2l3Events: Array<{
+    containmentEventId: string;
+    level: ContainmentLevel;
+    workflowId: string;
+    crpsId: string;
+    occurredAt: string;
+    explanation: string;
+  }>;
+  newPatterns: string[];
+  policyAdjustmentProposals: string[];
+  generatedAt: string;
+};
+
+export type GovernanceLedgerEventType =
+  | "risk_eval"
+  | "containment_applied"
+  | "foresight_task_created"
+  | "weekly_digest_published";
+
+export type GovernanceLedgerEvent = {
+  id: string;
+  eventType: GovernanceLedgerEventType;
+  runId: string | null;
+  workflowId: string;
+  crpsId: string | null;
+  payload: Record<string, unknown>;
+  createdAt: string;
+};
+
+export type GovernancePreflightInput = {
+  runId: string;
+  workflowId: string;
+  nodes: WorkflowNode[];
+  params?: Record<string, unknown>;
+  actorId?: string | null;
+  orgId?: string | null;
+};
+
+export type GovernancePreflightResult = {
+  crps: CrpsSignature;
+  policyDecision: PolicyDecision;
+  containment: ContainmentDecision;
+  simulationReport: SimulationReport | null;
+};
+
+export type GovernancePostRunInput = {
+  runId: string;
+  workflowId: string;
+  crpsId: string;
+  results: WorkflowStepResult[];
+};
+

--- a/rocketgpt_v3_full/webapp/next/scripts/governance/run-unit-tests.ts
+++ b/rocketgpt_v3_full/webapp/next/scripts/governance/run-unit-tests.ts
@@ -1,0 +1,132 @@
+import assert from "assert";
+
+import { applyContainmentDecision } from "../../lib/governance/containment-engine";
+import { aggregateWeeklyDigest } from "../../lib/governance/digest-aggregate";
+import { evaluatePolicyRules, DEFAULT_GOVERNANCE_RULES } from "../../lib/governance/policy-engine";
+import { createParamsFingerprint, redactSecrets } from "../../lib/governance/redaction";
+import { computeCrpsSignature } from "../../lib/governance/risk-scoring";
+import type { WorkflowNode } from "../../lib/workflow-types";
+
+function sampleNode(overrides: Partial<WorkflowNode> = {}): WorkflowNode {
+  return {
+    node_id: "n1",
+    cat_id: "CAT-A",
+    canonical_name: "cats/security/a",
+    name: "Security Guard",
+    purpose: "Protect policy boundaries",
+    allowed_side_effects: ["workflow_dispatch"],
+    requires_approval: true,
+    passport_required: true,
+    selection_reason: "risk-first",
+    score: 80,
+    init_params: {},
+    expected_behavior: "Validate and dispatch",
+    expected_outputs: [],
+    ...overrides,
+  };
+}
+
+function testCrpsDeterministic() {
+  const nodesA = [sampleNode({ cat_id: "CAT-2", node_id: "2" }), sampleNode({ cat_id: "CAT-1", node_id: "1" })];
+  const nodesB = [sampleNode({ cat_id: "CAT-1", node_id: "1" }), sampleNode({ cat_id: "CAT-2", node_id: "2" })];
+  const paramsA = { alpha: 1, zeta: 2, nested: { token: "secret" } };
+  const paramsB = { zeta: 2, nested: { token: "secret" }, alpha: 1 };
+
+  const crpsA = computeCrpsSignature({ workflowId: "wf-1", nodes: nodesA, params: paramsA });
+  const crpsB = computeCrpsSignature({ workflowId: "wf-1", nodes: nodesB, params: paramsB });
+  assert.strictEqual(crpsA.crpsId, crpsB.crpsId, "CRPS hash must be deterministic across ordering.");
+}
+
+function testPolicyTrigger() {
+  const crps = computeCrpsSignature({
+    workflowId: "wf-2",
+    nodes: [sampleNode({ purpose: "legal security incident response", allowed_side_effects: ["workflow_dispatch"] })],
+    params: { force: true },
+  });
+  const decision = evaluatePolicyRules(DEFAULT_GOVERNANCE_RULES, crps, {
+    repeatCount: 1,
+    redLineMatch: false,
+    approvalsMissing: true,
+    simulationMissing: false,
+  });
+  assert.ok(decision.containmentLevel >= 2, "Expected L2+ containment for high-risk policy conditions.");
+}
+
+function testContainmentTransitions() {
+  const l1 = applyContainmentDecision({
+    matchedRuleId: "l1",
+    matchedRuleName: "L1",
+    containmentLevel: 1,
+    explanation: "L1",
+    action: {
+      level: 1,
+      explainTemplate: "L1",
+      requireSimulationReport: true,
+      blockExecution: false,
+      requireApprovalCheckpoint: false,
+      disableAutoExec: false,
+      silent: true,
+    },
+  });
+  const l3 = applyContainmentDecision({
+    matchedRuleId: "l3",
+    matchedRuleName: "L3",
+    containmentLevel: 3,
+    explanation: "L3",
+    action: {
+      level: 3,
+      explainTemplate: "L3",
+      requireSimulationReport: true,
+      blockExecution: true,
+      requireApprovalCheckpoint: true,
+      disableAutoExec: true,
+      silent: false,
+    },
+  });
+  assert.strictEqual(l1.allowExecution, true, "L1 should allow execution.");
+  assert.strictEqual(l3.allowExecution, false, "L3 should block execution.");
+  assert.strictEqual(l3.blockExecution, true, "L3 must block execution.");
+}
+
+function testRedactionUtility() {
+  const raw = {
+    password: "abc",
+    nested: { apiKey: "key", token: "t", safe: "ok" },
+    safe: "value",
+  };
+  const redacted = redactSecrets(raw) as any;
+  assert.strictEqual(redacted.password, "[REDACTED]");
+  assert.strictEqual(redacted.nested.apiKey, "[REDACTED]");
+  assert.strictEqual(redacted.nested.safe, "ok");
+
+  const fp1 = createParamsFingerprint(raw as any);
+  const fp2 = createParamsFingerprint({ safe: "value", nested: { safe: "ok", token: "t", apiKey: "key" }, password: "abc" });
+  assert.strictEqual(fp1, fp2, "Fingerprint must stay stable across key order.");
+}
+
+function testWeeklyDigestShape() {
+  const digest = aggregateWeeklyDigest(
+    [
+      { crps_id: "a", workflow_id: "wf", risk_domains: ["security"] },
+      { crps_id: "a", workflow_id: "wf", risk_domains: ["security"] },
+      { crps_id: "b", workflow_id: "wf2", risk_domains: ["legal"] },
+    ],
+    [{ id: "e1", containment_level: 2, workflow_id: "wf", crps_id: "a", created_at: new Date().toISOString(), explanation: "x" }],
+    "2026-03-01T00:00:00.000Z",
+    "2026-03-07T23:59:59.999Z"
+  );
+  assert.ok(Array.isArray(digest.topPatterns), "Digest topPatterns should be an array.");
+  assert.ok(Array.isArray(digest.policyAdjustmentProposals), "Digest proposals should be an array.");
+  assert.ok(typeof digest.id === "string" && digest.id.length > 0, "Digest should have an id.");
+}
+
+function runAll() {
+  testCrpsDeterministic();
+  testPolicyTrigger();
+  testContainmentTransitions();
+  testRedactionUtility();
+  testWeeklyDigestShape();
+  console.log("governance unit tests: PASS");
+}
+
+runAll();

--- a/rocketgpt_v3_full/webapp/next/supabase/migrations/20260302_cats_governance_monitor.sql
+++ b/rocketgpt_v3_full/webapp/next/supabase/migrations/20260302_cats_governance_monitor.sql
@@ -1,0 +1,181 @@
+-- CATS Governance Monitor schema
+-- Safe to re-run (idempotent where possible)
+
+create schema if not exists governance;
+
+create table if not exists governance.crps_executions (
+  id uuid primary key default gen_random_uuid(),
+  run_id text not null,
+  org_id text null,
+  actor_id text null,
+  crps_id text not null,
+  workflow_id text not null,
+  cats_involved jsonb not null,
+  params_fingerprint text not null,
+  risk_domains jsonb not null,
+  impact_score integer not null check (impact_score between 0 and 100),
+  reversibility_score integer not null check (reversibility_score between 0 and 100),
+  aggressiveness_score integer not null check (aggressiveness_score between 0 and 100),
+  override_rate integer not null default 0 check (override_rate between 0 and 100),
+  confidence numeric(5,4) not null check (confidence >= 0 and confidence <= 1),
+  recommended_level smallint not null check (recommended_level in (1,2,3)),
+  evidence_refs jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_crps_executions_created_at on governance.crps_executions(created_at desc);
+create index if not exists idx_crps_executions_crps on governance.crps_executions(crps_id);
+
+create table if not exists governance.crps_weekly_patterns (
+  id uuid primary key default gen_random_uuid(),
+  week_start timestamptz not null,
+  crps_id text not null,
+  workflow_id text not null,
+  risk_domains jsonb not null default '[]'::jsonb,
+  execution_count integer not null default 0,
+  created_at timestamptz not null default now(),
+  unique(week_start, crps_id)
+);
+
+create table if not exists governance.policy_rules (
+  id text primary key,
+  name text not null,
+  enabled boolean not null default true,
+  priority integer not null default 0,
+  conditions jsonb not null default '{}'::jsonb,
+  action jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists governance.containment_events (
+  id uuid primary key default gen_random_uuid(),
+  run_id text not null,
+  workflow_id text not null,
+  crps_id text not null,
+  containment_level smallint not null check (containment_level in (1,2,3)),
+  decision_payload jsonb not null,
+  explanation text not null,
+  policy_rule_id text null,
+  policy_rule_name text null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_containment_events_created_at on governance.containment_events(created_at desc);
+create index if not exists idx_containment_events_level on governance.containment_events(containment_level);
+
+create table if not exists governance.foresight_tasks (
+  id uuid primary key default gen_random_uuid(),
+  crps_id text not null,
+  summary text not null,
+  why_it_matters text not null,
+  scenarios jsonb not null,
+  stop_conditions jsonb not null default '[]'::jsonb,
+  mitigation_if_late text not null,
+  recommended_policy_changes jsonb not null default '[]'::jsonb,
+  recommended_cat_patches jsonb not null default '[]'::jsonb,
+  domain_queues jsonb not null default '[]'::jsonb,
+  status text not null check (status in ('open','in_review','resolved')) default 'open',
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_foresight_tasks_status on governance.foresight_tasks(status);
+
+create table if not exists governance.weekly_digest_snapshots (
+  id text primary key,
+  week_start timestamptz not null,
+  week_end timestamptz not null,
+  digest_payload jsonb not null,
+  generated_at timestamptz not null default now()
+);
+
+create table if not exists governance.ledger_events (
+  id uuid primary key default gen_random_uuid(),
+  event_type text not null check (
+    event_type in (
+      'risk_eval',
+      'containment_applied',
+      'foresight_task_created',
+      'weekly_digest_published'
+    )
+  ),
+  run_id text null,
+  workflow_id text not null,
+  crps_id text null,
+  payload jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_governance_ledger_created_at on governance.ledger_events(created_at desc);
+create index if not exists idx_governance_ledger_event_type on governance.ledger_events(event_type);
+
+create or replace function governance.prevent_mutation()
+returns trigger
+language plpgsql
+as $$
+begin
+  raise exception 'governance.ledger_events is append-only';
+end;
+$$;
+
+drop trigger if exists trg_governance_ledger_no_update on governance.ledger_events;
+drop trigger if exists trg_governance_ledger_no_delete on governance.ledger_events;
+
+create trigger trg_governance_ledger_no_update
+before update on governance.ledger_events
+for each row execute function governance.prevent_mutation();
+
+create trigger trg_governance_ledger_no_delete
+before delete on governance.ledger_events
+for each row execute function governance.prevent_mutation();
+
+insert into governance.policy_rules (id, name, enabled, priority, conditions, action)
+values
+(
+  'default-l3-high-impact-low-reversibility',
+  'L3: High impact and low reversibility',
+  true,
+  100,
+  '{"impactScoreGte":85,"reversibilityScoreLte":30}'::jsonb,
+  '{"level":3,"explainTemplate":"Execution blocked: impact {impactScore} with reversibility {reversibilityScore} crossed emergency threshold.","lockParameters":["*"],"disableAutoExec":true,"requireApprovalCheckpoint":true,"requireSimulationReport":true,"blockExecution":true,"openIncident":true,"silent":false}'::jsonb
+),
+(
+  'default-l3-redline',
+  'L3: Red-line match',
+  true,
+  95,
+  '{"redLineMatch":true}'::jsonb,
+  '{"level":3,"explainTemplate":"Execution blocked due to red-line policy match in domains: {domains}.","lockParameters":["*"],"disableAutoExec":true,"requireApprovalCheckpoint":true,"requireSimulationReport":true,"blockExecution":true,"openIncident":true,"silent":false}'::jsonb
+),
+(
+  'default-l2-missing-approvals',
+  'L2: High impact with approvals missing',
+  true,
+  80,
+  '{"impactScoreGte":70,"approvalsMissing":true}'::jsonb,
+  '{"level":2,"explainTemplate":"Approval checkpoint required: impact {impactScore} is high and required approvals are missing.","lockParameters":["aggressiveMode","autoExecute","maxBudget"],"disableAutoExec":true,"requireApprovalCheckpoint":true,"requireSimulationReport":true,"blockExecution":false,"openIncident":false,"silent":false}'::jsonb
+),
+(
+  'default-l2-legal-security-confidence',
+  'L2: Legal/security domain with high confidence',
+  true,
+  70,
+  '{"domainsIncludeAny":["legal","security"],"confidenceGte":0.7}'::jsonb,
+  '{"level":2,"explainTemplate":"Approval checkpoint required for sensitive domains ({domains}) with high confidence.","lockParameters":["aggressiveMode","autoExecute","maxBudget"],"disableAutoExec":true,"requireApprovalCheckpoint":true,"requireSimulationReport":true,"blockExecution":false,"openIncident":false,"silent":false}'::jsonb
+),
+(
+  'default-l1-baseline',
+  'L1: Baseline containment',
+  true,
+  10,
+  '{"impactScoreGte":50}'::jsonb,
+  '{"level":1,"explainTemplate":"Soft containment applied for medium/high risk impact {impactScore}.","disableAutoExec":false,"requireApprovalCheckpoint":false,"requireSimulationReport":true,"blockExecution":false,"openIncident":false,"silent":true}'::jsonb
+)
+on conflict (id) do update set
+  name = excluded.name,
+  enabled = excluded.enabled,
+  priority = excluded.priority,
+  conditions = excluded.conditions,
+  action = excluded.action,
+  updated_at = now();
+


### PR DESCRIPTION
## What
Adds a CATS Governance Monitor:
- CRPS generation (deterministic hashing + redaction + risk scoring)
- Policy engine (L1/L2/L3) + containment engine
- Foresight tasks for L2/L3
- Weekly digest aggregation + persistence + ledger publication
- Append-only governance ledger table + triggers preventing update/delete
- Governance API routes:
  - GET /api/governance/crps
  - GET /api/governance/containment-events
  - GET /api/governance/foresight-tasks
  - GET/POST /api/governance/policies
  - GET /api/governance/digests
  - POST /api/governance/preflight
  - POST /api/governance/post-run
  - POST /api/governance/jobs/weekly-digest
- Minimal admin page: /super/governance
- Docs: docs/governance/cats-governance-monitor.md
- Migration: supabase/migrations/20260302_cats_governance_monitor.sql

## Why
Demo needs an explicit governance layer showing preflight risk checks, containment decisions, and weekly governance reporting.

## Validation
- npm run typecheck (clean)
- Note: npm run test:governance is not present in package.json (local run attempt failed with 'Missing script').