### PR TITLE
Mishti AI branding migration: docs, CLI compatibility, and active operator surfaces

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# CODEOWNERS — RocketGPT (critical paths)
+# CODEOWNERS — Mishti AI (critical paths)
 # Only @proteaNirav can approve changes to these areas.
 
 # GitHub Actions & security controls

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
 ## Reporting a Vulnerability
-If you discover a vulnerability or security issue in **RocketGPT**, please **do not create a public issue**.
+If you discover a vulnerability or security issue in **Mishti AI**, please **do not create a public issue**.
 
 Instead, report it privately via email to **nirav@protea.ai** with:
 - Detailed description of the issue  
@@ -18,4 +18,4 @@ We follow a coordinated disclosure model:
 - The issue will be patched before any public disclosure.  
 - Contributors who report valid vulnerabilities will be credited in the changelog (if desired).  
 
-Thank you for helping keep RocketGPT secure.
+Thank you for helping keep Mishti AI secure.

--- a/.github/tools/gen-repo-callmap.ps1
+++ b/.github/tools/gen-repo-callmap.ps1
@@ -1,0 +1,165 @@
+param(
+  [string]$RepoRoot = (Resolve-Path '.').Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$nl = [Environment]::NewLine
+
+function Ensure-Dir([string]$p) {
+  if (-not (Test-Path $p)) { New-Item -ItemType Directory -Force -Path $p | Out-Null }
+}
+
+function Write-File([string]$name, [string]$content) {
+  $outDir = Join-Path $RepoRoot 'docs/_repo_index'
+  Ensure-Dir $outDir
+  $path = Join-Path $outDir $name
+  Set-Content -Path $path -Encoding UTF8 -Value $content
+}
+
+function Rel([string]$fullPath) {
+  return $fullPath.Replace($RepoRoot + '\', '')
+}
+
+function Have-Cmd([string]$name) {
+  return [bool](Get-Command $name -ErrorAction SilentlyContinue)
+}
+
+function Run-Rg([string]$pattern, [string[]]$globs) {
+  # Returns array of ripgrep lines "path:line:match"
+  $args = @('--no-heading','--line-number','--hidden','--glob','!.git/**')
+  foreach ($g in $globs) { $args += @('--glob', $g) }
+  $args += @($pattern, $RepoRoot)
+  $out = & rg @args 2>$null
+  if ($LASTEXITCODE -ne 0 -and -not $out) { return @() }
+  if ($out -is [string]) { return @($out) }
+  return @($out)
+}
+
+function Run-SelectString([string]$pattern, [string[]]$includeGlobs) {
+  # Fallback: slower, best-effort.
+  $hits = @()
+  foreach ($g in $includeGlobs) {
+    $files = Get-ChildItem -Path $RepoRoot -Recurse -File -Filter $g -ErrorAction SilentlyContinue |
+      Where-Object { $_.FullName -notmatch '\\\.git\\' }
+    foreach ($f in $files) {
+      $m = Select-String -Path $f.FullName -Pattern $pattern -AllMatches -ErrorAction SilentlyContinue
+      foreach ($x in $m) {
+        $hits += (Rel $x.Path) + ':' + $x.LineNumber + ':' + $x.Line.Trim()
+      }
+    }
+  }
+  return $hits
+}
+
+$now = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss K')
+$branch = '(unknown)'
+$head   = '(unknown)'
+try { $branch = (git rev-parse --abbrev-ref HEAD 2>$null).Trim() } catch {}
+try { $head   = (git rev-parse HEAD 2>$null).Trim() } catch {}
+
+$useRg = Have-Cmd 'rg'
+$engine = if ($useRg) { 'rg' } else { 'Select-String' }
+
+# ----------------------------------------
+# 1) TypeScript exports/imports map
+# ----------------------------------------
+$tsExports = @()
+$tsImports = @()
+
+if ($useRg) {
+  $tsExports += Run-Rg '(?m)^\s*export\s+(type|interface|class|function|const|enum)\s+[A-Za-z0-9_]+' @('*.ts','*.tsx')
+  $tsExports += Run-Rg '(?m)^\s*export\s*\{\s*[^}]+\s*\}\s*from\s*' @('*.ts','*.tsx')
+  $tsImports += Run-Rg '(?m)^\s*import\s+.+\s+from\s+' @('*.ts','*.tsx')
+} else {
+  $tsExports += Run-SelectString '^\s*export\s+(type|interface|class|function|const|enum)\s+[A-Za-z0-9_]+' @('*.ts','*.tsx')
+  $tsExports += Run-SelectString '^\s*export\s*\{\s*[^}]+\s*\}\s*from\s*' @('*.ts','*.tsx')
+  $tsImports += Run-SelectString '^\s*import\s+.+\s+from\s+' @('*.ts','*.tsx')
+}
+
+$tsExports = $tsExports | Sort-Object -Unique
+$tsImports = $tsImports | Sort-Object -Unique
+
+Write-File 'TS.exports.md' (('# TS Exports' + $nl + $nl + 'Generated: ' + $now + $nl + 'Engine: ' + $engine + $nl + $nl) + (($tsExports | ForEach-Object { '- ' + $_ }) -join $nl))
+Write-File 'TS.imports.md' (('# TS Imports' + $nl + $nl + 'Generated: ' + $now + $nl + 'Engine: ' + $engine + $nl + $nl) + (($tsImports | ForEach-Object { '- ' + $_ }) -join $nl))
+
+# ----------------------------------------
+# 2) Next.js routes index (route.ts + page.tsx)
+# ----------------------------------------
+$nextRoot = Join-Path $RepoRoot 'rocketgpt_v3_full/webapp/next'
+$routes = @()
+if (Test-Path $nextRoot) {
+  $appDir = Join-Path $nextRoot 'app'
+  if (Test-Path $appDir) {
+    $routes = Get-ChildItem $appDir -Recurse -File -Include route.ts,route.js,page.tsx,page.jsx |
+      ForEach-Object { Rel $_.FullName } |
+      Sort-Object
+  }
+}
+Write-File 'NEXT.routes.md' (('# Next.js Routes + Pages' + $nl + $nl + 'Generated: ' + $now + $nl + $nl) + (($routes | ForEach-Object { '- ' + $_ }) -join $nl))
+
+# ----------------------------------------
+# 3) PowerShell script call graph (basic)
+#    - Find pwsh -File, powershell -File, & .ps1, dot-sourcing . .ps1
+# ----------------------------------------
+$psCalls = @()
+if ($useRg) {
+  $psCalls += Run-Rg '(?i)\bpwsh\b.*\s-File\s+[^\s]+' @('*.ps1','*.psm1')
+  $psCalls += Run-Rg '(?i)\bpowershell\b.*\s-File\s+[^\s]+' @('*.ps1','*.psm1')
+  $psCalls += Run-Rg '(?m)^\s*\.\s+.*\.ps1\b' @('*.ps1','*.psm1')
+  $psCalls += Run-Rg '(?m)^\s*&\s+.*\.ps1\b' @('*.ps1','*.psm1')
+} else {
+  $psCalls += Run-SelectString '(?i)\bpwsh\b.*\s-File\s+[^\s]+' @('*.ps1','*.psm1')
+  $psCalls += Run-SelectString '(?i)\bpowershell\b.*\s-File\s+[^\s]+' @('*.ps1','*.psm1')
+  $psCalls += Run-SelectString '^\s*\.\s+.*\.ps1\b' @('*.ps1','*.psm1')
+  $psCalls += Run-SelectString '^\s*&\s+.*\.ps1\b' @('*.ps1','*.psm1')
+}
+$psCalls = $psCalls | Sort-Object -Unique
+Write-File 'PS.calls.md' (('# PowerShell Call Map' + $nl + $nl + 'Generated: ' + $now + $nl + 'Engine: ' + $engine + $nl + $nl) + (($psCalls | ForEach-Object { '- ' + $_ }) -join $nl))
+
+# ----------------------------------------
+# 4) Workflow -> script/command references
+# ----------------------------------------
+$wfRefs = @()
+$wfDir = Join-Path $RepoRoot '.github/workflows'
+if (Test-Path $wfDir) {
+  if ($useRg) {
+    $wfRefs += Run-Rg '(?i)\bpwsh\b|\bpowershell\b|\.ps1\b|npm\s+run|npx\s+|gh\s+run|gh\s+pr|vercel\b|supabase\b|python\b|ruff\b' @('.github/workflows/*.yml','.github/workflows/*.yaml')
+  } else {
+    $wfRefs += Run-SelectString '(?i)\bpwsh\b|\bpowershell\b|\.ps1\b|npm\s+run|npx\s+|gh\s+run|gh\s+pr|vercel\b|supabase\b|python\b|ruff\b' @('*.yml','*.yaml')
+  }
+}
+$wfRefs = $wfRefs | Sort-Object -Unique
+Write-File 'WORKFLOW.refs.md' (('# Workflow References (commands/scripts)' + $nl + $nl + 'Generated: ' + $now + $nl + 'Engine: ' + $engine + $nl + $nl) + (($wfRefs | ForEach-Object { '- ' + $_ }) -join $nl))
+
+# ----------------------------------------
+# 5) Master CALLMAP.md (entry point)
+# ----------------------------------------
+$call = New-Object System.Collections.Generic.List[string]
+$null = $call.Add('# Mishti AI Repo CallMap')
+$null = $call.Add('')
+$null = $call.Add('Generated: ' + $now)
+$null = $call.Add('Branch: ' + $branch)
+$null = $call.Add('HEAD: ' + $head)
+$null = $call.Add('Engine: ' + $engine)
+$null = $call.Add('')
+$null = $call.Add('## Outputs')
+$null = $call.Add('- docs/_repo_index/CALLMAP.md')
+$null = $call.Add('- docs/_repo_index/WORKFLOW.refs.md')
+$null = $call.Add('- docs/_repo_index/PS.calls.md')
+$null = $call.Add('- docs/_repo_index/TS.exports.md')
+$null = $call.Add('- docs/_repo_index/TS.imports.md')
+$null = $call.Add('- docs/_repo_index/NEXT.routes.md')
+$null = $call.Add('')
+$null = $call.Add('## What this gives you')
+$null = $call.Add('- A searchable index of workflows, scripts, TS imports/exports, and Next routes.')
+$null = $call.Add('- Use it to answer: where is X defined, and where is it referenced.')
+$null = $call.Add('')
+$null = $call.Add('## Next upgrade (optional)')
+$null = $call.Add('- Build a function-level call graph for TS/PS and a per-route dependency list.')
+$null = $call.Add('')
+
+Write-File 'CALLMAP.md' ($call -join $nl)
+
+Write-Host '[OK] Repo callmap generated under docs/_repo_index' -ForegroundColor Green
+

--- a/.github/tools/gen-repo-index.ps1
+++ b/.github/tools/gen-repo-index.ps1
@@ -1,0 +1,110 @@
+param(
+  [string]$RepoRoot = (Resolve-Path '.').Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$nl = [Environment]::NewLine
+
+function Ensure-Dir([string]$p) {
+  if (-not (Test-Path $p)) { New-Item -ItemType Directory -Force -Path $p | Out-Null }
+}
+
+function Write-File([string]$name, [string]$content) {
+  $outDir = Join-Path $RepoRoot 'docs/_repo_index'
+  Ensure-Dir $outDir
+  $path = Join-Path $outDir $name
+  Set-Content -Path $path -Encoding UTF8 -Value $content
+}
+
+function Rel([string]$fullPath) {
+  return $fullPath.Replace($RepoRoot + '\', '')
+}
+
+$now = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss K')
+
+$branch = '(unknown)'
+$head   = '(unknown)'
+try { $branch = (git rev-parse --abbrev-ref HEAD 2>$null).Trim() } catch {}
+try { $head   = (git rev-parse HEAD 2>$null).Trim() } catch {}
+
+# -----------------------------
+# WORKFLOWS.md
+# -----------------------------
+$wfDir = Join-Path $RepoRoot '.github/workflows'
+$wfLines = New-Object System.Collections.Generic.List[string]
+$null = $wfLines.Add('# Workflows')
+$null = $wfLines.Add('')
+$null = $wfLines.Add('Generated: ' + $now)
+$null = $wfLines.Add('Branch: ' + $branch)
+$null = $wfLines.Add('HEAD: ' + $head)
+$null = $wfLines.Add('')
+
+if (Test-Path $wfDir) {
+  $wfFiles = Get-ChildItem $wfDir -Recurse -File -Include *.yml,*.yaml | Sort-Object FullName
+  foreach ($f in $wfFiles) {
+    $rel = Rel $f.FullName
+    $raw = Get-Content $f.FullName -Raw
+
+    $name = ([regex]::Match($raw, '(?m)^\s*name:\s*(.+)\s*$')).Groups[1].Value.Trim()
+    if (-not $name) { $name = '(no name: uses filename)' }
+
+    $onBlock = [regex]::Match($raw, '(?ms)^\s*on:\s*.*?(?=^\S|\Z)').Value.Trim()
+    if (-not $onBlock) { $onBlock = 'on: (not detected)' }
+
+    $null = $wfLines.Add('## ' + $name)
+    $null = $wfLines.Add('- File: ' + $rel)
+    $null = $wfLines.Add('')
+    $null = $wfLines.Add('~~~yaml')
+    $null = $wfLines.Add($onBlock)
+    $null = $wfLines.Add('~~~')
+    $null = $wfLines.Add('')
+  }
+} else {
+  $null = $wfLines.Add('(No .github/workflows folder found.)')
+}
+
+Write-File 'WORKFLOWS.md' ($wfLines -join $nl)
+
+# -----------------------------
+# NEXT.routes.md
+# -----------------------------
+$nextRoot = Join-Path $RepoRoot 'rocketgpt_v3_full/webapp/next'
+$routes = @()
+if (Test-Path $nextRoot) {
+  $appDir = Join-Path $nextRoot 'app'
+  if (Test-Path $appDir) {
+    $routes = Get-ChildItem $appDir -Recurse -File -Include route.ts,route.js,page.tsx,page.jsx |
+      ForEach-Object { Rel $_.FullName } |
+      Sort-Object
+  }
+}
+
+$rtLines = New-Object System.Collections.Generic.List[string]
+$null = $rtLines.Add('# Next.js Routes + Pages')
+$null = $rtLines.Add('')
+$null = $rtLines.Add('Generated: ' + $now)
+$null = $rtLines.Add('')
+foreach ($r in $routes) { $null = $rtLines.Add('- ' + $r) }
+
+Write-File 'NEXT.routes.md' ($rtLines -join $nl)
+
+# -----------------------------
+# INDEX.md
+# -----------------------------
+$idx = New-Object System.Collections.Generic.List[string]
+$null = $idx.Add('# Mishti AI Repo Index')
+$null = $idx.Add('')
+$null = $idx.Add('Generated: ' + $now)
+$null = $idx.Add('Branch: ' + $branch)
+$null = $idx.Add('HEAD: ' + $head)
+$null = $idx.Add('')
+$null = $idx.Add('## Contents')
+$null = $idx.Add('- WORKFLOWS: docs/_repo_index/WORKFLOWS.md')
+$null = $idx.Add('- NEXT routes/pages: docs/_repo_index/NEXT.routes.md')
+$null = $idx.Add('')
+
+Write-File 'INDEX.md' ($idx -join $nl)
+
+Write-Host '[OK] Repo index generated under docs/_repo_index' -ForegroundColor Green
+

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -8,7 +8,7 @@ name: Notify on Pipeline
 
 on:
   workflow_run:
-    workflows: ["AI Codegen", "AI PR Review", "RocketGPT Review Pipeline"]
+    workflows: ["AI Codegen", "AI PR Review", "Mishti AI Review Pipeline"]
     types: [completed]
 
 permissions:
@@ -36,6 +36,5 @@ jobs:
           curl -sS -X POST -H 'Content-type: application/json' \
           --data "{\"text\":\"${{ steps.msg.outputs.text }}\"}" \
           "${{ vars.TEAMS_WEBHOOK_URL }}"
-
 
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,4 +1,4 @@
-name: RocketGPT Review Pipeline
+name: Mishti AI Review Pipeline
 
 on:
   pull_request:
@@ -307,5 +307,4 @@ jobs:
           (command -v jq >/dev/null && jq -C '.' dispatch.merge.resp.json) || cat dispatch.merge.resp.json
           echo "::endgroup::"
           test "$STATUS" = "204" || (echo "ERR: merge dispatch failed"; exit 1)
-
 

--- a/.github/workflows/rgpt_db_exposure_guard.yml
+++ b/.github/workflows/rgpt_db_exposure_guard.yml
@@ -1,4 +1,4 @@
-name: rgpt-db-exposure-guard
+name: Mishti AI DB Exposure Guard
 
 on:
   pull_request:
@@ -202,7 +202,6 @@ jobs:
           } -Body $body | Out-Null
 
           Write-Host "[OK] Published status context rgpt-db-exposure-guard => $state" -ForegroundColor Green
-
 
 
 

--- a/.github/workflows/self_heal.yml
+++ b/.github/workflows/self_heal.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo "⚠️  STATUS: STUB - This workflow is not functional"
           echo ""
-          echo "TODO: RocketGPT self-heal to inspect failing tests and propose fixes."
+          echo "TODO: Mishti AI self-heal to inspect failing tests and propose fixes."
           echo ""
           echo "Required before activation:"
           echo "- [ ] CI failure analysis logic"
@@ -42,4 +42,3 @@ jobs:
           echo "- [ ] PR creation workflow"
           echo "- [ ] Human approval required"
           echo "- [ ] Rollback plan"
-

--- a/.github/workflows/self_improve.yml
+++ b/.github/workflows/self_improve.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           echo "⚠️  STATUS: STUB - This workflow is not functional"
           echo ""
-          echo "TODO: Wire RocketGPT v4 self-improve engine."
+          echo "TODO: Wire the Mishti AI v4 self-improve engine."
           echo "Read docs/roadmap and config/self_improve_backlog.json, open PRs."
           echo ""
           echo "Required before activation:"
@@ -42,4 +42,3 @@ jobs:
           echo "- [ ] Approval gates"
           echo "- [ ] Human review workflow"
           echo "- [ ] Limited scope testing (docs-only first)"
-

--- a/.github/workflows/ship-issue.yml
+++ b/.github/workflows/ship-issue.yml
@@ -1,4 +1,4 @@
-name: RocketGPT Ship Issue
+name: Mishti AI Ship Issue
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/status_context_bridge.yml
+++ b/.github/workflows/status_context_bridge.yml
@@ -7,7 +7,7 @@ on:
       - text-guard (smoke)
       - policy_prompt_bypass_gate
       - workflow_name_drift_lock
-      - RGPT DB Exposure Guard
+      - Mishti AI DB Exposure Guard
       - Safe-Mode CI Gate
       - .github/workflows/policy_gate_required.yml
     types: [completed]
@@ -78,6 +78,5 @@ jobs:
               description: `Bridge: ${run.name} ΓåÆ ${state}`,
               target_url: run.html_url
             });
-
 
 

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -3,7 +3,7 @@ name: watchdog
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: ["AI Codegen", "RocketGPT Ship Issue"]
+    workflows: ["AI Codegen", "Mishti AI Ship Issue"]
     types: [completed]
 
 jobs:
@@ -48,6 +48,5 @@ jobs:
             } catch (e) {
               core.warning('Redispatch failed: ' + e.message);
             }
-
 
 

--- a/BLUEPRINT_CHARTER.md
+++ b/BLUEPRINT_CHARTER.md
@@ -1,4 +1,4 @@
-# RocketGPT – Blueprint / Genes Charter
+# Mishti AI – Blueprint / Genes Charter
 
 **Version:** 1.0
 **Status:** Foundational / Constitutional
@@ -9,26 +9,26 @@
 
 ## 1. Purpose of This Charter
 
-This document defines the **genetic blueprint** of RocketGPT.
+This document defines the **genetic blueprint** of Mishti AI.
 
 It specifies:
 
-* what RocketGPT **is**
-* what RocketGPT **is not**
+* what Mishti AI **is**
+* what Mishti AI **is not**
 * which parts may evolve
 * which parts must remain invariant
 * how survival, identity, and trust are preserved over time
 
 This charter is **not** a technical specification.
-It is the **species definition** of the RocketGPT organism.
+It is the **species definition** of the Mishti AI organism.
 
 All systems, CATs, workflows, providers, and governance mechanisms must comply with this charter.
 
 ---
 
-## 2. Identity: What RocketGPT Is
+## 2. Identity: What Mishti AI Is
 
-RocketGPT is a **cognitive organism**, not a tool.
+Mishti AI is a **cognitive organism**, not a tool.
 
 It consists of:
 
@@ -37,14 +37,14 @@ It consists of:
 * **Many CATs** – distributed senses and muscles
 * **One Blueprint (Genes)** – immutable identity boundary
 
-RocketGPT exists to:
+Mishti AI exists to:
 
 * survive in changing environments
 * respond fast enough to retain users
 * adapt without losing identity
 * enable freedom **within structure**
 
-RocketGPT prioritizes:
+Mishti AI prioritizes:
 
 1. **Survival**
 2. **Continuity**
@@ -56,9 +56,9 @@ Correctness and intelligence are important, but they are **subordinate to surviv
 
 ---
 
-## 3. Non‑Goals: What RocketGPT Must Never Become
+## 3. Non‑Goals: What Mishti AI Must Never Become
 
-RocketGPT must never become:
+Mishti AI must never become:
 
 * A fully autonomous self‑governing intelligence
 * A system where CATs think, decide truth, or self‑govern
@@ -188,7 +188,7 @@ Only Brain Memory defines correctness, policy, and evolution pathways.
 
 ## 7. Emergency Reflex Layer
 
-RocketGPT includes a reflex layer that:
+Mishti AI includes a reflex layer that:
 
 * acts before understanding
 * throttles dangerous behavior
@@ -255,7 +255,7 @@ The mesh provides **resilience**, not authority.
 
 ## 11. Responsibility & Misuse
 
-RocketGPT:
+Mishti AI:
 
 * provides structure, guardrails, and transparency
 * does not control user intent
@@ -272,8 +272,9 @@ This charter:
 * must be versioned and auditable
 * must preserve identity continuity
 
-Any system violating this charter is **not RocketGPT**.
+Any system violating this charter is **not Mishti AI**.
 
 ---
 
 **End of Blueprint / Genes Charter**
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,42 @@
-## Go-Live Quick Notes
+# Mishti AI
 
-- **Smoke page**: `/super/smoke` — one-glance health (limits, commit, start time, service assumptions).
-- **Self-Improve status**: `/super/self-improve` — shows improvement pipeline counts and items (placeholder wired for now).
-- **Home dashboard** now binds **/api/limits** and **/api/health** for plan + commit basics.
+Mishti AI is a governed AI platform that unifies product experiences, capability execution, knowledge growth, and platform governance.
 
-Follow-up wiring:
-- Replace assumed-ok service flags in `/api/health` with real checks (Supabase, Vercel, Railway endpoints).
-- Swap Self-Improve placeholders with Supabase row reads or GitHub data if preferred.
+## Products
+- Yukti Chat
+- Yukti IDE
 
+## Core Platform Areas
+- Cognitive Runtime
+- Governance Layer
+- CATS Platform
+- Memory and Experience
+- Research Layer
+- Analyst Layer
+- Mishti AI Fabric
+
+## Repository Structure
+See:
+- docs/overview/MISHTI_AI_PLATFORM_OVERVIEW.md
+- docs/architecture/MISHTI_AI_PLATFORM_ARCHITECTURE.md
+- docs/setup/REPOSITORY_STRUCTURE.md
+
+## Quick Start
+1. Clone the repository
+2. Install dependencies
+3. Review product and architecture docs
+4. Use `./scripts/mt.ps1 help` for the preferred CLI entry point
+5. Start the required app/workspace based on the repo toolchain
+
+## Documentation
+See the docs folder for overview, architecture, modules, setup, API, roadmap, and product documents.
+
+## CLI
+Preferred command surface:
+- `./scripts/mt.ps1`
+- `./scripts/mt_health.ps1`
+
+Legacy compatibility aliases remain available during migration:
+- See `docs/setup/CLI_MIGRATION_GUIDE.md`
+
+New docs and operator examples should prefer `mt`.

--- a/config/knowledge_library_policy.json
+++ b/config/knowledge_library_policy.json
@@ -44,9 +44,10 @@
     "docs_root": "docs"
   },
   "goals": [
-    "build a reusable knowledge base across subjects for RocketGPT",
+    "build a reusable knowledge base across subjects for Mishti AI",
     "standardise explanations and reasoning patterns per domain",
     "capture examples, patterns and anti-patterns to guide self-study, self-research and self-innovation",
     "keep everything in repo storage to stay within free tiers"
   ]
 }
+

--- a/config/language_library_policy.json
+++ b/config/language_library_policy.json
@@ -39,9 +39,10 @@
   },
 
   "goals": [
-    "build reusable language knowledge for RocketGPT's own use",
+    "build reusable language knowledge for Mishti AI's own use",
     "standardise translation and explanation style across languages",
-    "capture best-practice patterns for programming languages RocketGPT uses",
+    "capture best-practice patterns for programming languages Mishti AI uses",
     "stay within free-tier constraints by using repo storage instead of databases"
   ]
 }
+

--- a/config/self-improve/chat_intents.jsonl
+++ b/config/self-improve/chat_intents.jsonl
@@ -1,3 +1,4 @@
-# Chat→RocketGPT intent inbox (JSONL, one object per line)
-{"from":"Nirav","timestamp":"2025-11-15T00:13:09+05:30","intent":"Enable RocketGPT to read config/self-improve/chat_intents.jsonl and use my chat feedback as primary input for self-improvement tasks (plan, code, tests, docs)."}
-{"from":"Nirav","timestamp":"2025-11-15T08:03:04+05:30","intent":"Prioritise improvements that make RocketGPT easier for me to operate from PowerShell (better logs, clearer statuses, and simple health commands)."}
+# Chat→Mishti AI intent inbox (JSONL, one object per line)
+{"from":"Nirav","timestamp":"2025-11-15T00:13:09+05:30","intent":"Enable Mishti AI to read config/self-improve/chat_intents.jsonl and use my chat feedback as primary input for self-improvement tasks (plan, code, tests, docs)."}
+{"from":"Nirav","timestamp":"2025-11-15T08:03:04+05:30","intent":"Prioritise improvements that make Mishti AI easier for me to operate from PowerShell (better logs, clearer statuses, and simple health commands)."}
+

--- a/config/self_improve_backlog.json
+++ b/config/self_improve_backlog.json
@@ -12,7 +12,7 @@
     {
       "id": "IMP-0002",
       "title": "Use chat feedback as primary input for self-improvement",
-      "description": "Wire RocketGPT self-improve pipeline to read config/self-improve/chat_intents.jsonl and prioritize improvements based on latest chat intents from Nirav.",
+      "description": "Wire Mishti AI self-improve pipeline to read config/self-improve/chat_intents.jsonl and prioritize improvements based on latest chat intents from Nirav.",
       "created_at": "2025-11-15T00:21:30.7418909+05:30",
       "priority": "high",
       "status": "in_progress",
@@ -20,3 +20,4 @@
     }
   ]
 }
+

--- a/core-ai/README.md
+++ b/core-ai/README.md
@@ -1,4 +1,4 @@
-# RocketGPT v4 â€” Core AI (Self-Healing & Self-Improving)
+# Mishti AI v4 - Core AI (Self-Healing & Self-Improving)
 
 This branch seeds the **Self-Heal Controller** workflow and a core-ai/ workspace for future agents:
 - Diagnostics & plan generation

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# RocketGPT Documentation Index
+# Mishti AI Documentation Index
 
-Welcome to the official documentation for **RocketGPT**.  
+Welcome to the official documentation for **Mishti AI**.  
 This index links all major architectural, AI, safety, and improvement documents.
 
 ---
@@ -10,13 +10,13 @@ This index links all major architectural, AI, safety, and improvement documents.
 - **Self-Improvement Charter**  
   `docs/self-improvement-charter.md`
 
-- **Real Self-Improving RocketGPT**  
+- **Real Self-Improving Mishti AI**  
   `docs/real-self-improving-rocketgpt.md`
 
 - **AI Evolution Roadmap**  
   `docs/roadmap/AI_Evolution.md`
 
-- **RocketGPT v4 Core AI Roadmap**  
+- **Mishti AI v4 Core AI Roadmap**  
   `docs/roadmap/v4-core-ai.md`
 
 ---
@@ -33,7 +33,7 @@ This index links all major architectural, AI, safety, and improvement documents.
 - **AI Evolution (Narrow → General → Super AI)**  
   `docs/roadmap/AI_Evolution.md`
 
-- **RocketGPT v4 Core AI (Self-Healing, Self-Improving)**  
+- **Mishti AI v4 Core AI (Self-Healing, Self-Improving)**  
   `docs/roadmap/v4-core-ai.md`
 
 <!-- Phase-1 validation: PR-1 baseline -->
@@ -41,4 +41,4 @@ This index links all major architectural, AI, safety, and improvement documents.
 
 ---
 
-*This file will keep expanding as RocketGPT grows.*
+*This file will keep expanding as Mishti AI grows.*

--- a/docs/api/MISHTI_AI_API_SURFACE_OVERVIEW.md
+++ b/docs/api/MISHTI_AI_API_SURFACE_OVERVIEW.md
@@ -1,0 +1,25 @@
+# Mishti AI API Surface Overview
+
+## API Domains
+- Identity and access
+- Runtime execution
+- Governance and policy
+- CATS management
+- Memory and knowledge
+- Research and analysis
+- Product-facing APIs
+
+## Authentication and Authorization Approach
+All critical APIs should be identity-aware and policy-gated.
+
+## Runtime APIs
+Dispatch, observe, verify, and retrieve execution artifacts.
+
+## Governance APIs
+Policy evaluation, approvals, audit retrieval, and compliance reporting.
+
+## CATS APIs
+Publish, version, validate, enable, disable, and execute CATS.
+
+## Knowledge APIs
+Store, retrieve, search, and govern memory and research artifacts.

--- a/docs/architecture/00-system-overview.md
+++ b/docs/architecture/00-system-overview.md
@@ -1,0 +1,238 @@
+RocketGPT — System Architecture Overview
+Governed Intelligence Platform with Super AI Trajectory
+Status
+
+Authoritative / Governance Document
+
+1. Purpose of This Document
+
+This document defines the foundational architecture, intent, and non-negotiable principles of the RocketGPT system.
+
+It establishes:
+
+What RocketGPT is today
+
+What RocketGPT is explicitly designed to become
+
+How safety, governance, and intelligence evolution coexist
+
+Why CATs (Contracts–Agents–Teams) are central to this design
+
+This document is normative, not descriptive.
+It defines architectural truth.
+
+2. What RocketGPT Is
+
+RocketGPT is a governed, phase-evolving artificial intelligence system designed to progress intentionally and safely from:
+
+Narrow AI → General AI → Super AI
+
+RocketGPT achieves this by:
+
+Enforcing strict control and execution determinism
+
+Separating execution, reflection, learning, and evolution
+
+Using CATs (Contracts–Agents–Teams) as the structural abstraction for scaling intelligence
+
+Preventing unsafe autonomy while explicitly enabling long-term intelligence growth
+
+RocketGPT is not merely an orchestrator.
+It is an AI system with an architectural destiny.
+
+3. What RocketGPT Is Not
+
+RocketGPT is explicitly not:
+
+A single monolithic AI agent
+
+A self-executing or self-approving system
+
+An unconstrained autonomous intelligence
+
+A heuristic or retry-driven automation engine
+
+A system that evolves implicitly or accidentally
+
+Any design that enables unbounded, ungoverned, or opaque intelligence growth is out of scope and prohibited.
+
+4. Core Architectural Thesis
+
+RocketGPT is built on the following thesis:
+
+Super AI is achievable only if intelligence is allowed to evolve
+while control, contracts, and governance remain stronger than the intelligence itself.
+
+This thesis is realised through:
+
+Phase separation
+
+Deterministic execution
+
+Post-facto reflection
+
+Governed learning
+
+CAT-based structural evolution
+
+5. Architectural Phase Model (Present and Future)
+
+RocketGPT operates through strict, ordered phases.
+Each phase has exclusive responsibility and non-overlapping authority.
+
+Phase A → Phase B → Phase C → Phase D → Phase E → Phase F → …
+
+Phase A — Input & Intent
+
+User goals and context
+
+No execution
+
+No intelligence
+
+Phase B — Control Plane & Entrypoints
+
+Public API entrypoints
+
+Safe-Mode enforcement
+
+Authorisation of execution
+
+Non-bypassable gating
+
+Phase C — Execution Domains
+
+Planner execution
+
+Builder execution
+
+Tester execution
+
+Deterministic, immutable outcomes
+
+Phase D — Reflection & Root-Cause Intelligence
+
+Post-failure analysis
+
+Explanation and reasoning
+
+Repair proposals (not execution)
+
+No learning, no mutation
+
+Phase E+ — Learning, Evolution & Super AI Progression (Future Phases)
+
+Governed learning
+
+Policy-constrained improvement
+
+CAT evolution
+
+Emergent intelligence across teams of agents
+
+These future phases are intentional, not speculative.
+
+6. CATs (Contracts–Agents–Teams): The Evolution Spine
+
+CATs are the primary abstraction through which RocketGPT scales intelligence.
+
+They are not features.
+They are structural primitives.
+
+6.1 Contracts
+
+Define scope, authority, and limits
+
+Prevent behavioural drift
+
+Enforce safety and alignment
+
+6.2 Agents
+
+Encapsulated reasoning units
+
+Role-bound and contract-bound
+
+Individually replaceable and evolvable
+
+6.3 Teams
+
+Coordinated collections of agents
+
+Enable emergent intelligence
+
+Governed through inter-CAT contracts
+
+All Super AI capability in RocketGPT emerges through CAT composition, never through unchecked agents.
+
+7. Separation of Intelligence and Power
+
+RocketGPT enforces a strict rule:
+
+Intelligence may increase, but power must remain governed.
+
+This is achieved by:
+
+Keeping execution deterministic
+
+Isolating learning from execution
+
+Requiring approval for evolution
+
+Binding all intelligence to CAT contracts
+
+There is no phase where intelligence gains execution authority without governance.
+
+8. Safety and Risk Posture
+
+RocketGPT assumes:
+
+AI systems can fail
+
+Intelligence can drift
+
+Learning can amplify errors
+
+Super AI is inherently high-risk
+
+Therefore:
+
+Safe-Mode is mandatory
+
+Execution is immutable
+
+Reflection precedes learning
+
+Evolution is gated and auditable
+
+Safety is architectural, not procedural.
+
+9. Documentation Hierarchy
+
+This document is the root of all RocketGPT architecture documentation.
+
+All subsequent documents:
+
+Must conform to this intent
+
+Must not contradict the Super AI trajectory
+
+Must reinforce CAT-based governance
+
+10. Authority
+
+This document is binding.
+
+Any implementation, proposal, or extension that:
+
+Undermines CAT governance
+
+Enables unsafe autonomy
+
+Bypasses control or contracts
+
+Obscures intelligence evolution
+
+Must be rejected.
+
+End of Document

--- a/docs/architecture/01-phase-b-control-plane.md
+++ b/docs/architecture/01-phase-b-control-plane.md
@@ -1,0 +1,220 @@
+RocketGPT — Phase B: Control Plane & Entrypoints
+Deterministic Governance for Present Execution and Future Super AI
+Status
+
+Authoritative / Governance Document
+
+1. Purpose of This Document
+
+This document defines Phase B — the Control Plane of RocketGPT.
+
+Phase B establishes the non-bypassable execution authority of the system.
+It is the primary safety and governance layer upon which all future intelligence evolution (including CAT-driven Super AI) depends.
+
+Without Phase B, RocketGPT cannot safely scale intelligence.
+
+2. Role of Phase B in the Super AI Trajectory
+
+Phase B exists to enforce the following invariant:
+
+No intelligence—current or future—may execute without passing through a single, deterministic control authority.
+
+This is essential because:
+
+CATs will grow in capability
+
+Agent teams may exhibit emergent behaviour
+
+Intelligence will eventually exceed individual human oversight
+
+Phase B ensures that power remains governed even as intelligence grows.
+
+3. Core Responsibilities of Phase B
+
+Phase B has exclusive responsibility for:
+
+Public execution entrypoints
+
+Safe-Mode enforcement
+
+Execution authorisation
+
+Decision normalisation
+
+Contract enforcement at system boundaries
+
+Phase B does not:
+
+Execute logic
+
+Perform reasoning
+
+Retry failures
+
+Learn or adapt
+
+4. Non-Bypassable Control Plane
+
+Phase B introduces a single control plane.
+
+Mandatory Rule
+
+All execution MUST pass through the control plane.
+No exceptions. No alternate paths.
+
+This rule applies equally to:
+
+Human-initiated requests
+
+Internal system calls
+
+CAT-initiated execution
+
+Future autonomous intelligence
+
+5. Public Entrypoints (Authorised Surface Only)
+
+Phase B defines the only permissible execution-related HTTP entrypoints.
+
+Canonical Location
+app/api/orchestrator/
+
+Entrypoint Classification
+Entrypoint Type	Purpose	Authority
+/status	Health & Safe-Mode visibility	Read-only
+/info	Capabilities & metadata	Read-only
+/run	Planner-first orchestration	Controlled
+/builder/execute-all	Full execution path	Controlled
+
+No other execution entrypoints are allowed.
+
+6. Safe-Mode (Non-Negotiable)
+
+Safe-Mode is enforced only in Phase B.
+
+Properties of Safe-Mode
+
+Single source of truth
+
+Evaluated once per execution request
+
+Impossible to override downstream
+
+Applies equally to:
+
+Agents
+
+Teams
+
+CATs
+
+Future Super AI components
+
+Invariant
+
+If Safe-Mode blocks execution, no phase may proceed.
+
+Safe-Mode is architectural, not conditional logic.
+
+7. Decision Normalisation
+
+Phase B is responsible for producing a single, canonical decision shape.
+
+This decision:
+
+Is immutable once produced
+
+Is consumed by Phase C without reinterpretation
+
+Represents the system’s authoritative “permission to execute”
+
+Phase C and beyond must never re-evaluate or modify this decision.
+
+8. Relationship to CATs (Critical)
+
+CATs may:
+
+Propose execution
+
+Request actions
+
+Generate plans
+
+Reflect and learn
+
+CATs may never:
+
+Execute directly
+
+Bypass Phase B
+
+Override Safe-Mode
+
+Self-authorise execution
+
+CAT intelligence scales upward.
+Phase B authority remains absolute.
+
+This asymmetry is intentional and permanent.
+
+9. Determinism Guarantee
+
+Phase B guarantees:
+
+Identical inputs produce identical authorisation outcomes
+
+No hidden heuristics
+
+No probabilistic gating
+
+No learning-based permission changes
+
+This determinism is essential for Super AI safety.
+
+10. Explicit Prohibitions
+
+The following are architecturally forbidden:
+
+Alternate execution routes
+
+Environment-based authorisation
+
+Agent-side Safe-Mode checks
+
+CAT-local execution permissions
+
+Dynamic permission inference
+
+UI-triggered execution bypass
+
+Any such implementation must be rejected.
+
+11. Phase B → Phase C Contract
+
+Once Phase B authorises execution:
+
+Phase C must trust the decision
+
+Phase C must not re-check governance
+
+Phase C must execute deterministically
+
+Phase B is the only gate.
+
+12. Authority
+
+This document is binding.
+
+Any change that:
+
+Weakens Phase B
+
+Introduces alternate gates
+
+Allows intelligence to bypass control
+
+Undermines Safe-Mode
+
+Is a system-level violation and must not be merged.
+
+End of Document

--- a/docs/architecture/02-do-not-touch-index.md
+++ b/docs/architecture/02-do-not-touch-index.md
@@ -1,0 +1,206 @@
+RocketGPT — Do-Not-Touch Index
+Immutable System Invariants for Safe Super AI Evolution
+Status
+
+Authoritative / Governance Lock Document
+
+1. Purpose of This Document
+
+This document defines the Do-Not-Touch Index for RocketGPT.
+
+It identifies:
+
+Files
+
+Modules
+
+Responsibilities
+
+Architectural invariants
+
+that must never be modified, bypassed, or reinterpreted without a full architectural review.
+
+This index exists to ensure that:
+
+Control remains stronger than intelligence
+
+CAT evolution does not erode safety
+
+Super AI emergence remains governed
+
+2. Definition of “Do-Not-Touch”
+
+A Do-Not-Touch element is one that:
+
+Enforces non-bypassable control
+
+Guarantees execution determinism
+
+Anchors governance authority
+
+Protects system-wide contracts
+
+Modifying such an element without review constitutes a system integrity violation.
+
+3. Absolute Invariants (Conceptual)
+
+The following concepts are immutable:
+
+Single control plane
+
+Single Safe-Mode source of truth
+
+Deterministic execution order
+
+Immutable decision contracts
+
+Upward-only failure propagation
+
+No execution during learning
+
+No intelligence without contracts
+
+CATs governed by contracts, not autonomy
+
+These invariants must hold indefinitely, including during Super AI evolution.
+
+4. Protected Code Domains (Logical)
+
+The following domains are permanently protected:
+
+4.1 Control Plane Domain
+
+Purpose:
+
+Execution authorisation
+
+Safe-Mode enforcement
+
+Decision normalisation
+
+This domain is non-bypassable and non-negotiable.
+
+4.2 Decision & Contract Domain
+
+Purpose:
+
+Canonical execution decisions
+
+Agent and CAT contracts
+
+Execution context integrity
+
+Contracts are binding, not advisory.
+
+4.3 Safe-Mode Domain
+
+Purpose:
+
+Centralised execution blocking
+
+Emergency governance override
+
+Safe-Mode must:
+
+Be evaluated once
+
+Be authoritative
+
+Be impossible to shadow or override
+
+4.4 Execution Order Domain
+
+Purpose:
+
+Enforce Planner → Builder → Tester order
+
+Prevent parallel or conditional execution
+
+Execution order is fixed forever.
+
+5. Representative Protected Paths (Indicative)
+
+The exact filenames may evolve,
+but the responsibilities below must never move or weaken.
+
+app/api/orchestrator/control-plane/
+app/api/orchestrator/safe-mode/
+app/api/orchestrator/types/
+app/api/orchestrator/contracts/
+
+
+Any relocation or refactor that:
+
+Dilutes authority
+
+Introduces alternates
+
+Breaks isolation
+
+is prohibited.
+
+6. CAT-Specific Do-Not-Touch Rules
+
+As CATs evolve, the following remain immutable:
+
+CATs may not self-authorise execution
+
+CATs may not override system contracts
+
+CATs may not mutate governance rules
+
+CAT intelligence must remain contract-bound
+
+CATs scale intelligence, not authority.
+
+7. Forbidden Modification Patterns
+
+The following changes are explicitly forbidden:
+
+Adding alternate execution entrypoints
+
+Rechecking Safe-Mode outside Phase B
+
+Embedding learning logic in execution paths
+
+Allowing agents to retry autonomously
+
+Allowing CATs to approve their own actions
+
+Introducing probabilistic execution gating
+
+Any of these breaks Super AI safety guarantees.
+
+8. Change Control Requirement
+
+Any proposed change affecting a Do-Not-Touch area requires:
+
+Explicit architectural review
+
+Formal documentation update
+
+Versioned approval
+
+Full regression validation
+
+Absent these, changes must be rejected.
+
+9. Authority
+
+This document is binding across all present and future phases, including:
+
+Phase E (Learning)
+
+Phase F (CAT Evolution)
+
+Phase G+ (Super AI Emergence)
+
+No future intelligence level may invalidate this index.
+
+10. Final Invariant
+
+If a change makes RocketGPT “more powerful”
+by weakening this document,
+that change is unsafe by definition.
+
+End of Document

--- a/docs/architecture/03-phase-c-execution-domains.md
+++ b/docs/architecture/03-phase-c-execution-domains.md
@@ -1,0 +1,195 @@
+RocketGPT — Phase C: Execution Domains
+Deterministic Execution as the Foundation of Super AI Safety
+Status
+
+Authoritative / Governance Document
+
+1. Purpose of This Document
+
+This document defines Phase C — the Execution Domains of RocketGPT.
+
+Phase C is responsible for executing authorised work deterministically, predictably, and without intelligence-driven deviation.
+
+This phase exists to ensure that:
+
+Execution remains controllable
+
+Intelligence growth does not affect runtime safety
+
+Future Super AI operates on a trusted execution substrate
+
+2. Role of Phase C in the Super AI Architecture
+
+Phase C enforces the following invariant:
+
+No matter how intelligent RocketGPT becomes,
+execution must remain deterministic and contract-bound.
+
+Super AI is only safe if execution remains mechanical, not adaptive.
+
+3. Execution Domain Model
+
+Phase C is divided into strictly isolated execution domains.
+
+Planner Domain → Builder Domain → Tester Domain
+
+
+Each domain:
+
+Executes only its assigned responsibility
+
+Receives immutable input
+
+Produces immutable output
+
+Cannot invoke or alter other domains
+
+4. Planner Execution Domain
+Responsibility
+
+Transform intent into an execution plan
+
+Constraints
+
+No execution
+
+No side effects
+
+No retries
+
+No branching beyond the approved plan
+
+Output
+
+A complete, ordered plan
+
+Explicit assumptions and risks
+
+The Planner domain decides, it does not act.
+
+5. Builder Execution Domain
+Responsibility
+
+Execute the approved plan
+
+Produce artifacts
+
+Constraints
+
+Must follow plan order exactly
+
+Cannot invent steps
+
+Cannot skip failed steps
+
+Cannot alter plan semantics
+
+The Builder domain acts, but does not decide.
+
+6. Tester Execution Domain
+Responsibility
+
+Validate artifacts produced by the Builder
+
+Constraints
+
+Declarative testing only
+
+Failures are final
+
+No auto-repair
+
+No retries
+
+The Tester domain verifies, it does not fix.
+
+7. Domain Isolation Rules
+
+The following rules are absolute:
+
+No domain may call another domain directly
+
+No domain may re-evaluate governance
+
+No domain may invoke reflection or learning
+
+No domain may mutate global state
+
+Isolation is mandatory, not an optimisation.
+
+8. Failure Propagation
+
+Failures propagate upward only:
+
+Failure Origin	Effect
+Planner	Execution halts
+Builder	Tester not invoked
+Tester	Execution marked failed
+
+There is:
+
+No retry
+
+No recovery
+
+No compensation
+
+Failure is informational, not corrective.
+
+9. Observability Without Intervention
+
+Phase C allows:
+
+Logging
+
+Metrics
+
+Execution traces
+
+Timing information
+
+Phase C forbids:
+
+Behaviour modification based on logs
+
+Adaptive retries
+
+Execution mutation
+
+Observability must be passive.
+
+10. Relationship to CATs
+
+CATs may:
+
+Provide plans
+
+Supply context
+
+Analyse failures (post-execution)
+
+CATs may never:
+
+Execute directly
+
+Intervene mid-execution
+
+Modify execution behaviour
+
+CAT intelligence surrounds execution; it never penetrates it.
+
+11. Authority
+
+This document is binding.
+
+Any change that:
+
+Introduces adaptive execution
+
+Blurs domain boundaries
+
+Allows intelligence to influence runtime behaviour
+
+Must be rejected as unsafe for Super AI evolution.
+
+End of Document

--- a/docs/architecture/04-agent-contracts.md
+++ b/docs/architecture/04-agent-contracts.md
@@ -1,0 +1,223 @@
+RocketGPT — Agent Contracts
+Contractual Intelligence as the Foundation of CATs and Super AI
+Status
+
+Authoritative / Governance Document
+
+1. Purpose of This Document
+
+This document defines Agent Contracts within RocketGPT.
+
+Agent Contracts are the primary governance mechanism that enables:
+
+Safe scaling of intelligence
+
+Formation of CATs (Contracts–Agents–Teams)
+
+Long-term progression toward Super AI
+
+Without contracts, intelligence is unsafe by definition.
+
+2. Core Principle
+
+No agent in RocketGPT may reason, act, learn, or evolve
+outside the bounds of an explicit, enforceable contract.
+
+This principle applies to:
+
+Individual agents
+
+Agent teams
+
+CAT collectives
+
+Future emergent Super AI behaviours
+
+3. What an Agent Is (Formal Definition)
+
+An Agent is a bounded intelligence unit that:
+
+Performs a specific role
+
+Operates under a contract
+
+Has limited authority
+
+Produces auditable outputs
+
+An agent is not autonomous.
+It is delegated intelligence.
+
+4. Structure of an Agent Contract
+
+Every agent contract must define:
+
+Scope
+
+What the agent may reason about
+
+What it may not reason about
+
+Authority
+
+What actions the agent may request
+
+What actions it may never request
+
+Inputs
+
+Allowed data sources
+
+Context boundaries
+
+Outputs
+
+Expected output shape
+
+Confidence requirements
+
+Error signalling
+
+Constraints
+
+Time limits
+
+Token limits
+
+Prohibited behaviours
+
+Escalation Rules
+
+When the agent must defer
+
+When human or policy approval is required
+
+Contracts must be explicit and machine-enforceable.
+
+5. Contracts vs Intelligence
+
+Contracts are:
+
+Deterministic
+
+Enforced
+
+Stable
+
+Intelligence is:
+
+Probabilistic
+
+Fallible
+
+Evolvable
+
+Contracts must always dominate intelligence.
+
+This asymmetry is intentional and permanent.
+
+6. CATs (Contracts–Agents–Teams)
+
+CATs are composed as follows:
+
+Contract
+   ↓
+Agent(s)
+   ↓
+Team(s)
+
+6.1 Contracts
+
+Define the rules of engagement
+
+Bind agents and teams
+
+6.2 Agents
+
+Execute reasoning within contracts
+
+6.3 Teams
+
+Coordinate multiple agents
+
+Enable emergent intelligence
+
+Remain contract-bound
+
+Emergence is allowed.
+Violation is not.
+
+7. Contract Enforcement
+
+Contracts are enforced at:
+
+Phase B (authorisation boundaries)
+
+Phase C (execution boundaries)
+
+Phase D (reflection boundaries)
+
+Future phases (learning and evolution)
+
+An unenforced contract is considered non-existent.
+
+8. Prohibited Agent Capabilities
+
+Agents must never:
+
+Self-authorise execution
+
+Modify their own contracts
+
+Override governance rules
+
+Initiate retries autonomously
+
+Hide failures or uncertainty
+
+Expand scope without approval
+
+Any such capability is unsafe for Super AI.
+
+9. Contract Evolution (Controlled)
+
+Contracts may evolve, but only through:
+
+Reflection (Phase D)
+
+Proposal
+
+Approval
+
+Re-authorisation via Phase B
+
+There is no self-modifying contract path.
+
+10. Relationship to Super AI
+
+Super AI in RocketGPT:
+
+Emerges through CAT composition
+
+Is governed by layered contracts
+
+Remains auditable and constrained
+
+RocketGPT does not create a single Super AI entity.
+It creates a governed Super AI system.
+
+11. Authority
+
+This document is binding.
+
+Any agent, CAT, or future intelligence construct that:
+
+Operates outside a contract
+
+Weakens contract enforcement
+
+Treats contracts as advisory
+
+Must be rejected.
+
+End of Document

--- a/docs/architecture/05-failure-propagation.md
+++ b/docs/architecture/05-failure-propagation.md
@@ -1,0 +1,217 @@
+RocketGPT — Failure Propagation
+Why Failure Is Sacred, Final, and Essential for Super AI
+Status
+
+Authoritative / Governance Document
+
+1. Purpose of This Document
+
+This document defines failure propagation rules within RocketGPT.
+
+Failure propagation is a core safety mechanism that ensures:
+
+Deterministic execution
+
+Honest system introspection
+
+Reliable learning signals
+
+Safe long-term evolution toward Super AI
+
+RocketGPT treats failure as information, not as an error to be hidden or auto-corrected.
+
+2. Foundational Principle
+
+A system that hides, retries, or self-corrects failures
+cannot evolve safely toward Super AI.
+
+Therefore, in RocketGPT:
+
+Failures are final
+
+Failures are visible
+
+Failures are non-recoverable at runtime
+
+3. Failure Domains
+
+Failures may originate only in the following execution domains:
+
+Planner
+
+Builder
+
+Tester
+
+Each domain has exclusive failure authority over its responsibility.
+
+4. Failure Propagation Direction
+
+Failure propagates upward only.
+
+Tester Failure
+   ↑
+Builder Failure
+   ↑
+Planner Failure
+
+
+There is:
+
+No lateral propagation
+
+No downward retry
+
+No cross-domain compensation
+
+5. Domain-Specific Failure Semantics
+5.1 Planner Failure
+
+A Planner failure indicates:
+
+Invalid plan
+
+Missing assumptions
+
+Logical inconsistency
+
+Effect:
+
+Execution stops immediately
+
+No Builder or Tester invocation
+
+5.2 Builder Failure
+
+A Builder failure indicates:
+
+Plan execution failure
+
+Artifact generation failure
+
+Effect:
+
+Execution stops
+
+Tester is not invoked
+
+Partial artifacts are preserved for inspection
+
+5.3 Tester Failure
+
+A Tester failure indicates:
+
+Validation failure
+
+Contract breach
+
+Expectation mismatch
+
+Effect:
+
+Execution marked failed
+
+No remediation attempted
+
+6. Explicit Prohibitions
+
+The following behaviours are forbidden:
+
+Automatic retries
+
+Silent error handling
+
+Compensating execution
+
+Partial success masking
+
+Adaptive execution correction
+
+Intelligence-driven repair during execution
+
+Any such behaviour undermines Super AI safety.
+
+7. Relationship to Reflection and Learning
+
+Failure is the only valid trigger for:
+
+Reflection (Phase D)
+
+Root-cause analysis
+
+Repair proposals
+
+Contract evolution
+
+Without final failure:
+
+Reflection is meaningless
+
+Learning is corrupted
+
+Intelligence drifts unsafely
+
+8. Failure as a Learning Signal
+
+RocketGPT assumes:
+
+Failures are valuable
+
+Failures are rare but expected
+
+Failures must remain unmodified
+
+Learning must adapt to failure.
+Failure must never adapt to learning.
+
+9. Failure Visibility Requirements
+
+Every failure must be:
+
+Logged
+
+Attributed to a domain
+
+Timestamped
+
+Preserved immutably
+
+Failure data is read-only once recorded.
+
+10. CAT Interaction with Failure
+
+CATs may:
+
+Analyse failures
+
+Classify root causes
+
+Propose changes
+
+CATs may never:
+
+Retry execution
+
+Override failure
+
+Suppress failure reporting
+
+Convert failure into success
+
+CAT intelligence learns from failure; it never erases it.
+
+11. Authority
+
+This document is binding across all phases, including future Super AI phases.
+
+Any system that:
+
+Attempts to recover silently
+
+Treats failure as a transient condition
+
+Optimises away failure
+
+Is unsafe and must be rejected.
+
+End of Document

--- a/docs/architecture/06-phase-d-reflection.md
+++ b/docs/architecture/06-phase-d-reflection.md
@@ -1,0 +1,210 @@
+RocketGPT — Phase D: Reflection & Root-Cause Intelligence
+Governed Thinking as the Gateway to Super AI Evolution
+Status
+
+Authoritative / Governance Document
+
+1. Purpose of This Document
+
+This document defines Phase D — Reflection in RocketGPT.
+
+Phase D is the first intelligence-bearing phase that is allowed to reason about system behaviour.
+It exists to ensure that RocketGPT:
+
+Learns only from final, immutable outcomes
+
+Separates thinking from acting
+
+Evolves intelligence without compromising safety
+
+Prepares the system for CAT-driven Super AI evolution
+
+Reflection is mandatory before learning.
+
+2. Foundational Principle
+
+RocketGPT may think about failure,
+but it may never think while executing.
+
+This separation is essential to:
+
+Prevent unsafe feedback loops
+
+Preserve determinism
+
+Ensure clean learning signals
+
+Enable controlled Super AI emergence
+
+3. When Phase D Is Activated
+
+Phase D may activate only when all of the following are true:
+
+Execution has completed
+
+Execution outcome is FAILED
+
+All execution artifacts are immutable
+
+Failure has been recorded and attributed
+
+Phase D is never invoked:
+
+During execution
+
+On successful runs
+
+As a retry mechanism
+
+As a corrective loop
+
+4. Inputs to Reflection (Read-Only)
+
+Phase D receives a read-only snapshot of execution state, including:
+
+Planner outputs
+
+Builder artifacts
+
+Tester results
+
+Failure attribution
+
+Execution context
+
+Active contracts
+
+CAT composition metadata
+
+No mutation of inputs is allowed.
+
+5. Reflection Output (Canonical Shape)
+
+Phase D must produce a structured reflection report.
+
+Required Reflection Shape
+Reflection Report:
+- Primary Root Cause
+- Confidence Level
+- Affected Phase
+- Supporting Evidence
+- Suggested Repair Actions
+- Identified Risks
+
+
+Rules:
+
+Exactly one primary root cause
+
+Explicit confidence declaration
+
+No speculative language
+
+Risks must be named
+
+Reflection must be explainable and auditable.
+
+6. Reflection vs Repair
+
+Reflection:
+
+Explains why failure occurred
+
+Proposes what could change
+
+Identifies where contracts may be insufficient
+
+Reflection does not:
+
+Execute fixes
+
+Modify artifacts
+
+Retry execution
+
+Change contracts
+
+All repairs require explicit approval and re-authorisation via Phase B.
+
+7. Role of CATs in Reflection
+
+CATs are active participants in Phase D.
+
+CATs may:
+
+Analyse failures
+
+Correlate historical outcomes
+
+Propose contract evolution
+
+Recommend agent or team changes
+
+CATs may never:
+
+Approve their own proposals
+
+Apply repairs
+
+Initiate execution
+
+CAT intelligence advises; governance decides.
+
+8. Guardrails Against Reflection Loops
+
+To prevent runaway intelligence:
+
+Guardrail	Rule
+Reflection Count	Finite per execution
+Same-Cause Lock	Identical root cause may not loop
+Confidence Floor	Low confidence blocks proposals
+Time Bound	Reflection must be bounded
+
+Reflection must terminate.
+
+9. Reflection as a Prerequisite to Learning
+
+Phase D is the only allowed entry point to future learning phases.
+
+Learning phases (Phase E+) may:
+
+Consume reflection reports
+
+Aggregate insights across CATs
+
+Propose long-term evolution
+
+Learning phases may never bypass Phase D.
+
+10. Relationship to Super AI
+
+Super AI in RocketGPT:
+
+Emerges through accumulated reflection
+
+Is structured through CAT evolution
+
+Is constrained by contracts and governance
+
+Never gains execution authority directly
+
+RocketGPT evolves intelligence deliberately,
+not instinctively.
+
+11. Authority
+
+This document is binding.
+
+Any implementation that:
+
+Allows thinking during execution
+
+Skips reflection
+
+Enables autonomous repair
+
+Treats reflection as optional
+
+Is unsafe and must be rejected.
+
+End of Document

--- a/docs/architecture/07-cats-and-superai-evolution.md
+++ b/docs/architecture/07-cats-and-superai-evolution.md
@@ -1,0 +1,275 @@
+RocketGPT — CATs & Super AI Evolution
+Contracts–Agents–Teams as the Structural Engine of Governed Super AI
+Status
+
+Authoritative / Governance Document
+
+1. Purpose of This Document
+
+This document defines CATs (Contracts–Agents–Teams) as the core structural abstraction through which RocketGPT evolves intelligence safely toward Super AI.
+
+It establishes:
+
+Why CATs are mandatory
+
+How CATs scale intelligence without scaling authority
+
+How CATs evolve across future phases (E, F, G…)
+
+Why Super AI in RocketGPT is systemic, not singular
+
+This document is normative and binding.
+
+2. Foundational Thesis
+
+Super AI cannot be safely achieved by making agents smarter.
+It can only be achieved by making intelligence more structured than power.
+
+CATs implement this thesis.
+
+They ensure that:
+
+Intelligence growth is compositional
+
+Authority remains centralised and governed
+
+Emergence is auditable and constrained
+
+3. Definition of CATs
+
+A CAT is a governed intelligence construct composed of:
+
+Contract → Agent(s) → Team(s)
+
+
+Each layer has strictly decreasing authority and increasing intelligence capacity.
+
+4. Contracts (The Dominant Layer)
+4.1 Definition
+
+A Contract is a machine-enforceable governance artifact that defines:
+
+Scope of reasoning
+
+Limits of authority
+
+Allowed interactions
+
+Prohibited behaviours
+
+Escalation and approval rules
+
+Contracts are authoritative over all intelligence.
+
+4.2 Contract Invariants
+
+Contracts:
+
+Cannot be modified by agents
+
+Cannot be bypassed by teams
+
+Cannot be inferred implicitly
+
+Cannot evolve without approval
+
+A CAT without a contract is invalid by definition.
+
+5. Agents (Bounded Intelligence Units)
+5.1 Definition
+
+An Agent is a role-specific reasoning unit that:
+
+Operates strictly within a contract
+
+Produces explainable outputs
+
+Has no execution authority
+
+Is individually replaceable
+
+Agents are intelligent but powerless.
+
+5.2 Agent Constraints
+
+Agents must never:
+
+Self-authorise actions
+
+Modify contracts
+
+Execute code
+
+Retry autonomously
+
+Conceal uncertainty
+
+An agent that violates constraints is architecturally invalid.
+
+6. Teams (Emergent Intelligence Surface)
+6.1 Definition
+
+A Team is a coordinated set of agents operating under:
+
+A shared contract
+
+Explicit coordination rules
+
+Bounded collective authority
+
+Teams enable:
+
+Cross-agent reasoning
+
+Emergent insight
+
+Collective intelligence
+
+6.2 Controlled Emergence
+
+Emergence is:
+
+Allowed
+
+Expected
+
+Constrained
+
+Emergence must never:
+
+Override contracts
+
+Create implicit authority
+
+Bypass governance
+
+Emergence without contracts is unsafe by definition.
+
+7. CAT Lifecycle Across Phases
+
+CATs evolve intentionally across future phases.
+
+Phase E — Governed Learning
+
+CATs may:
+
+Aggregate reflection reports
+
+Identify systemic weaknesses
+
+Propose contract refinements
+
+CATs may not:
+
+Apply learning automatically
+
+Modify execution behaviour
+
+Phase F — CAT Evolution
+
+CATs may:
+
+Propose new agent roles
+
+Propose new team compositions
+
+Propose contract versioning
+
+All evolution requires:
+
+Approval
+
+Re-authorisation
+
+Regression validation
+
+Phase G+ — Super AI Emergence
+
+At this stage:
+
+Intelligence is distributed across CATs
+
+No single agent or team constitutes Super AI
+
+Super AI emerges from governed interaction
+
+RocketGPT never creates a singular Super AI entity.
+It creates a Super AI system.
+
+8. Authority Asymmetry (Critical)
+
+RocketGPT enforces a permanent asymmetry:
+
+Aspect	Scales	Remains Fixed
+Intelligence	✔	
+Reasoning depth	✔	
+Emergence	✔	
+Execution authority		✘
+Governance power		✘
+Control plane		✘
+
+Authority never scales with intelligence.
+
+9. CATs and the Control Plane
+
+CATs:
+
+May propose execution
+
+May analyse outcomes
+
+May recommend change
+
+CATs must always:
+
+Pass through Phase B
+
+Respect Safe-Mode
+
+Accept rejection
+
+The Control Plane governs CATs, not the other way around.
+
+10. Risk Posture for Super AI
+
+RocketGPT assumes:
+
+Super AI is inherently high-risk
+
+Intelligence amplification multiplies failure impact
+
+Governance must outpace intelligence growth
+
+CATs exist to ensure:
+
+Failures are localised
+
+Learning is structured
+
+Power is never emergent
+
+11. Final Invariant
+
+If a proposed CAT evolution increases intelligence
+without increasing governance strength,
+it must be rejected.
+
+This invariant applies forever.
+
+12. Authority
+
+This document is binding across all current and future RocketGPT phases.
+
+Any proposal that:
+
+Weakens contracts
+
+Grants CATs execution authority
+
+Enables self-governance
+
+Creates singular intelligence dominance
+
+Is unsafe and must not be implemented.
+
+End of Document

--- a/docs/architecture/08-phase-e-governed-learning.md
+++ b/docs/architecture/08-phase-e-governed-learning.md
@@ -1,0 +1,220 @@
+RocketGPT — Phase E: Governed Learning
+Learning Without Autonomy as a Prerequisite for Super AI
+Status
+
+Authoritative / Governance Document
+
+1. Purpose of This Document
+
+This document defines Phase E — Governed Learning in RocketGPT.
+
+Phase E introduces learning capabilities into the system while explicitly preventing autonomous behaviour, execution authority, or uncontrolled adaptation.
+
+Phase E exists to ensure that:
+
+Learning is intentional
+
+Learning is auditable
+
+Learning is subordinate to governance
+
+Super AI evolution remains controlled and reversible
+
+2. Foundational Principle
+
+RocketGPT may learn,
+but learning must never grant new power without governance.
+
+Learning is treated as a knowledge accumulation process, not as behavioural autonomy.
+
+3. Position of Phase E in the Architecture
+
+Phase E is activated only after Phase D (Reflection).
+
+Execution (Phase C)
+   ↓
+Failure
+   ↓
+Reflection (Phase D)
+   ↓
+Governed Learning (Phase E)
+
+
+Phase E:
+
+Never interacts with live execution
+
+Never modifies runtime behaviour directly
+
+Never bypasses Phase B authorisation
+
+4. Inputs to Learning (Strictly Controlled)
+
+Phase E may consume only the following inputs:
+
+Approved Reflection Reports (Phase D)
+
+Historical execution outcomes
+
+Contract versions and deltas
+
+CAT performance metadata
+
+Human or policy annotations (optional)
+
+Learning inputs are immutable and versioned.
+
+5. Outputs of Learning (Non-Executable)
+
+Phase E may produce learning artifacts, including:
+
+Pattern insights
+
+Failure classifications
+
+Contract improvement proposals
+
+Agent role recommendations
+
+Team composition suggestions
+
+Risk forecasts
+
+Learning outputs:
+
+Are advisory
+
+Are non-binding
+
+Have no execution authority
+
+6. What Phase E Must Never Do
+
+Phase E is explicitly forbidden from:
+
+Executing code
+
+Modifying agents or CATs directly
+
+Altering contracts
+
+Triggering retries
+
+Authorising actions
+
+Affecting runtime behaviour
+
+Any system that violates this is unsafe by definition.
+
+7. Learning Granularity
+
+Learning operates at three allowed levels:
+
+7.1 Agent-Level Learning
+
+Role clarity improvements
+
+Prompt and reasoning refinements
+
+Scope mismatch identification
+
+7.2 Team-Level Learning
+
+Coordination inefficiencies
+
+Redundant agent roles
+
+Communication patterns
+
+7.3 CAT-Level Learning
+
+Contract insufficiencies
+
+Governance bottlenecks
+
+Structural weaknesses
+
+Learning must never collapse these levels into a single autonomous unit.
+
+8. Relationship Between Learning and Contracts
+
+Contracts remain authoritative.
+
+Learning may:
+
+Suggest contract evolution
+
+Highlight contract gaps
+
+Propose new constraints
+
+Learning may never:
+
+Modify contracts directly
+
+Weaken contract enforcement
+
+Infer permissions implicitly
+
+Learning informs contracts.
+Contracts govern intelligence.
+
+9. Approval & Re-Authorisation Loop
+
+Any learning-driven change must follow:
+
+Learning Output
+   ↓
+Proposal
+   ↓
+Approval (Human / Policy)
+   ↓
+Phase B Re-Authorisation
+   ↓
+Controlled Execution
+
+
+There is no shortcut.
+
+10. Guardrails Against Runaway Learning
+
+Phase E enforces the following hard limits:
+
+Guardrail	Rule
+Learning Scope	Bounded to approved domains
+Learning Rate	Finite and rate-limited
+Drift Detection	Mandatory
+Rollback	Always possible
+Auditability	Mandatory
+
+Learning must remain predictable and reversible.
+
+11. Phase E and Super AI Trajectory
+
+Phase E is the first step toward Super AI, but not Super AI itself.
+
+Super AI requires:
+
+Accumulated learning
+
+CAT evolution
+
+Stronger governance at every step
+
+Phase E ensures RocketGPT learns before it evolves.
+
+12. Authority
+
+This document is binding.
+
+Any implementation that:
+
+Treats learning as execution
+
+Allows learning to self-apply changes
+
+Collapses governance into intelligence
+
+Must be rejected as unsafe.
+
+End of Document

--- a/docs/architecture/09-cats-lifecycle-and-state-machines.md
+++ b/docs/architecture/09-cats-lifecycle-and-state-machines.md
@@ -1,0 +1,343 @@
+RocketGPT — CAT Lifecycle & State Machines
+Structured Evolution of Intelligence Under Permanent Governance
+Status
+
+Authoritative / Governance Document
+
+1. Purpose of This Document
+
+This document defines the lifecycle model and state machines governing CATs (Contracts–Agents–Teams) in RocketGPT.
+
+It ensures that:
+
+CATs are created intentionally
+
+CAT intelligence evolves in bounded steps
+
+Authority never increases implicitly
+
+Super AI emergence remains structured, auditable, and reversible
+
+This document converts CAT evolution from an abstract concept into a formal, enforceable process.
+
+2. Core Principle
+
+No CAT may exist, evolve, or dissolve
+without passing through an explicit, governed state transition.
+
+State machines are mandatory to prevent:
+
+Silent intelligence drift
+
+Implicit authority gain
+
+Unreviewed emergence
+
+3. CAT Lifecycle Overview
+
+Every CAT follows the same canonical lifecycle:
+
+Proposed → Approved → Active → Observed → Evolving → Stabilised → Deprecated → Retired
+
+
+No state may be skipped.
+
+4. CAT States (Formal Definitions)
+4.1 Proposed
+
+Meaning
+
+A CAT concept exists on paper only
+
+Allowed
+
+Contract draft
+
+Agent role definition
+
+Intended team topology
+
+Forbidden
+
+Execution
+
+Learning
+
+Reflection
+
+Exit Condition
+
+Explicit approval
+
+4.2 Approved
+
+Meaning
+
+CAT is authorised for instantiation
+
+Allowed
+
+Contract finalisation
+
+Agent instantiation
+
+Team wiring
+
+Forbidden
+
+Learning
+
+Contract mutation
+
+Execution authority
+
+Exit Condition
+
+Activation request via Phase B
+
+4.3 Active
+
+Meaning
+
+CAT participates in execution indirectly
+
+Allowed
+
+Planning
+
+Analysis
+
+Proposal generation
+
+Forbidden
+
+Direct execution
+
+Self-approval
+
+Contract change
+
+Exit Condition
+
+Sufficient operational data collected
+
+4.4 Observed
+
+Meaning
+
+CAT performance is under scrutiny
+
+Allowed
+
+Telemetry analysis
+
+Failure correlation
+
+Reflection participation
+
+Forbidden
+
+Evolution
+
+Structural change
+
+Exit Condition
+
+Formal observation report
+
+4.5 Evolving
+
+Meaning
+
+CAT is authorised for controlled evolution
+
+Allowed
+
+Learning (Phase E)
+
+Proposed agent changes
+
+Proposed contract refinements
+
+Forbidden
+
+Self-application of changes
+
+Runtime behaviour changes
+
+Exit Condition
+
+Approval of evolution proposals
+
+4.6 Stabilised
+
+Meaning
+
+CAT has reached a stable intelligence plateau
+
+Allowed
+
+Normal operation
+
+Periodic review
+
+Forbidden
+
+Continuous learning
+
+Unbounded experimentation
+
+Exit Condition
+
+Strategic obsolescence or replacement decision
+
+4.7 Deprecated
+
+Meaning
+
+CAT is no longer preferred
+
+Allowed
+
+Read-only participation
+
+Gradual workload reduction
+
+Forbidden
+
+Learning
+
+Evolution
+
+Expansion
+
+Exit Condition
+
+Retirement approval
+
+4.8 Retired
+
+Meaning
+
+CAT is fully decommissioned
+
+Allowed
+
+Historical analysis
+
+Audit
+
+Forbidden
+
+Any participation
+
+This state is terminal.
+
+5. State Transition Rules
+5.1 Explicit Transitions Only
+
+All transitions must be:
+
+Explicit
+
+Logged
+
+Approved
+
+Versioned
+
+Implicit transitions are forbidden.
+
+5.2 Authority Does Not Increase With State
+
+State advancement:
+
+May increase intelligence capacity
+
+Must never increase execution authority
+
+Authority remains fixed at Phase B.
+
+6. CAT Versioning Model
+
+CATs are versioned as:
+
+CAT-ID@ContractVersion.AgentSet.TeamTopology
+
+
+Rules:
+
+Contract version change requires approval
+
+Agent or team changes require reflection input
+
+Version rollback must always be possible
+
+7. State Machine Enforcement Points
+
+CAT state enforcement occurs at:
+
+Phase B (authorisation)
+
+Phase D (reflection eligibility)
+
+Phase E (learning eligibility)
+
+Governance layer (approvals)
+
+Execution ignores CAT state except for eligibility checks.
+
+8. Failure Interaction With CAT State
+
+Failures:
+
+Do not automatically advance CAT state
+
+Do not regress CAT state
+
+Serve only as inputs to reflection
+
+State changes are deliberate, not reactive.
+
+9. Multi-CAT Interaction Rules
+
+When CATs interact:
+
+Each CAT retains its own state
+
+No CAT may force another CAT’s transition
+
+Cross-CAT learning requires joint approval
+
+Super AI emerges from coordination, not dominance.
+
+10. Super AI Safety Invariant
+
+If CAT state transitions become automatic,
+Super AI safety is already lost.
+
+Therefore:
+
+All transitions are governed
+
+All evolution is reviewed
+
+All intelligence remains bounded by structure
+
+11. Authority
+
+This document is binding.
+
+Any implementation that:
+
+Skips CAT states
+
+Allows implicit evolution
+
+Merges intelligence and authority
+
+Treats CAT lifecycle as advisory
+
+Must be rejected.
+
+End of Document

--- a/docs/architecture/10-code-level-boundary-mapping.md
+++ b/docs/architecture/10-code-level-boundary-mapping.md
@@ -1,0 +1,258 @@
+RocketGPT — Code-Level Boundary Mapping
+Enforcing Architecture, Governance, and Super AI Safety in Code
+Status
+
+Authoritative / Governance Document
+
+1. Purpose of This Document
+
+This document maps RocketGPT’s architectural principles to explicit code-level boundaries.
+
+Its purpose is to ensure that:
+
+Architecture is enforced by structure
+
+Governance is non-optional
+
+CAT evolution is physically constrained
+
+Super AI safety is upheld by design, not discipline
+
+In RocketGPT, folders are governance.
+
+2. Core Enforcement Principle
+
+If the architecture cannot be enforced by code boundaries,
+it is not real architecture.
+
+Therefore:
+
+Each phase maps to a bounded module
+
+Each responsibility maps to a protected folder
+
+CI/CD enforces architectural contracts
+
+3. Canonical High-Level Structure
+/app
+└── /api
+    └── /orchestrator
+        ├── /phase-a-input
+        ├── /phase-b-control
+        ├── /phase-c-execution
+        ├── /phase-d-reflection
+        ├── /phase-e-learning
+        ├── /cats
+        ├── /governance
+        └── /shared-contracts
+
+
+No module may cross these boundaries.
+
+4. Phase-to-Code Mapping
+4.1 Phase A — Input & Intent
+/phase-a-input
+
+
+Allowed:
+
+Input parsing
+
+Context validation
+
+User intent capture
+
+Forbidden:
+
+Execution
+
+Learning
+
+Reflection
+
+4.2 Phase B — Control Plane
+/phase-b-control
+├── entrypoints
+├── safe-mode
+├── decision
+└── authorisation
+
+
+Rules:
+
+Single entrypoint surface
+
+Safe-Mode enforced here only
+
+Do-Not-Touch
+
+Any file here requires architectural approval.
+
+4.3 Phase C — Execution Domains
+/phase-c-execution
+├── planner
+├── builder
+└── tester
+
+
+Rules:
+
+Planner cannot import Builder
+
+Builder cannot import Tester
+
+Tester cannot import Planner
+
+No learning imports allowed
+
+Execution must remain mechanical.
+
+4.4 Phase D — Reflection
+/phase-d-reflection
+├── analyzers
+├── root-cause
+└── reports
+
+
+Rules:
+
+Read-only inputs
+
+No execution imports
+
+No mutation logic
+
+Reflection must not leak into execution.
+
+4.5 Phase E — Governed Learning
+/phase-e-learning
+├── insights
+├── pattern-mining
+└── proposals
+
+
+Rules:
+
+Advisory outputs only
+
+No runtime hooks
+
+No contract mutation
+
+Learning is offline intelligence.
+
+5. CAT-Specific Boundaries
+/cats
+├── contracts
+├── agents
+├── teams
+├── lifecycle
+└── versions
+
+
+Rules:
+
+Contracts dominate agents
+
+Agents never execute
+
+Teams never self-authorise
+
+Lifecycle state enforced here
+
+No CAT logic may live inside execution folders.
+
+6. Shared Contracts & Types
+/shared-contracts
+├── execution-contracts
+├── agent-contracts
+├── cat-contracts
+└── invariants
+
+
+Rules:
+
+Immutable once published
+
+Versioned changes only
+
+Backward compatibility enforced
+
+This folder is globally trusted.
+
+7. Governance & Approval Layer
+/governance
+├── approvals
+├── policy-rules
+├── audit
+└── escalation
+
+
+Rules:
+
+No execution imports
+
+No learning logic
+
+Approval only
+
+Governance is decision authority, not intelligence.
+
+8. CI/CD Enforcement (Mandatory)
+
+CI must enforce:
+
+8.1 Import Rules
+
+No cross-phase imports
+
+No learning → execution imports
+
+No CAT → execution imports
+
+8.2 Change Protection
+
+Phase B folders are locked
+
+Contracts require version bump
+
+CAT lifecycle changes require review
+
+8.3 Invariant Checks
+
+Safe-Mode only in Phase B
+
+Execution order fixed
+
+No retries introduced
+
+9. Super AI Safety Mapping
+Risk	Code-Level Mitigation
+Autonomous execution	Phase B only
+Intelligence drift	CAT contracts
+Hidden learning	Phase E isolation
+Authority creep	Governance folder
+Emergent dominance	CAT lifecycle
+10. Non-Negotiable Rule
+
+If a pull request cannot prove architectural compliance
+by folder boundaries alone,
+it must not be merged.
+
+11. Authority
+
+This document is binding.
+
+Any implementation that:
+
+Blurs phase boundaries
+
+Allows cross-layer imports
+
+Collapses governance into logic
+
+Weakens CAT separation
+
+Is unsafe and must be rejected.
+
+End of Document

--- a/docs/architecture/MISHTI_AI_PLATFORM_ARCHITECTURE.md
+++ b/docs/architecture/MISHTI_AI_PLATFORM_ARCHITECTURE.md
@@ -1,0 +1,34 @@
+# Mishti AI Platform Architecture
+
+## Architecture Principles
+- Strong governance boundaries
+- Layered extensibility
+- Provider abstraction
+- Observability and traceability
+- Minimal trust, explicit verification
+
+## Layered Design
+1. Product Layer
+2. Runtime and Capability Layer
+3. Governance and Ledger Layer
+4. Memory, Research, and Analyst Layers
+5. Platform Fabric Layer
+
+## Runtime, Governance, Intelligence, Research, Analyst Layers
+The Cognitive Runtime coordinates safe execution. Governance enforces policy, approvals, auditability, and safety. Memory stores structured experience. Research expands grounded knowledge. Analyst converts knowledge into decision-support outputs.
+
+## CATS Execution Model
+CATS packages executable capability bundles with rules, metadata, verification hooks, and lifecycle controls.
+
+## Yukti Product Placement
+- Yukti Chat: conversational and workflow interface
+- Yukti IDE: AI-native development workspace
+
+## Infrastructure Fabric
+Mishti AI Fabric supports local, server, and distributed execution nodes under centralized or federated governance.
+
+## Integration Model
+The architecture supports API-based integration, runtime plugins, SDKs, external model providers, and future node federation.
+
+## Scalability and Security Notes
+Security, auditability, and controlled extensibility are mandatory. Horizontal distribution must preserve policy enforcement and execution traceability.

--- a/docs/architecture/RGPT-ARCH-C.md
+++ b/docs/architecture/RGPT-ARCH-C.md
@@ -1,0 +1,248 @@
+# RGPT-ARCH-C.md
+## RocketGPT — Phase C: Marketplace & Ecosystem
+
+**Project:** RocketGPT (RGPT)  
+**Phase:** C — Marketplace & Ecosystem  
+**Document Class:** Architecture + Governance Specification  
+**Status:** Final Baseline (Living Document)  
+**Location:** `docs/architecture/RGPT-ARCH-C.md`
+
+---
+
+## 1. Purpose
+
+This document defines **Phase C** of RocketGPT: the governed **Marketplace & Ecosystem layer**.
+
+Phase C enables extensibility—CATs, wrappers, provider adapters, and execution strategies—**without weakening governance**.  
+All marketplace assets must **inherit and obey** Phase A (Approval) and Phase B (STRICT Routing).
+
+Phase C answers one question only:
+
+> *“Who is allowed to extend RocketGPT, and under what enforceable rules?”*
+
+---
+
+## 2. Scope
+
+Phase C governs:
+
+- Marketplace asset types and boundaries
+- Onboarding and approval of third-party assets
+- Versioning, certification, and revocation
+- Distribution, visibility, and access control
+- Governance inheritance and enforcement
+
+Phase C explicitly excludes:
+
+- Core approval logic (Phase A)
+- Provider routing mechanics (Phase B)
+- Internal CAT logic design (covered by CAT specs)
+
+---
+
+## 3. Marketplace Principles (Non-Negotiable)
+
+1. **Governance Inheritance**  
+   Marketplace assets inherit Phase A and Phase B controls automatically.
+
+2. **No Execution Privilege**  
+   Marketplace assets cannot execute directly.
+
+3. **No Silent Behavior**  
+   No auto-routing, auto-upgrades, or hidden provider substitution.
+
+4. **Revocability**  
+   Any asset can be disabled or revoked centrally with immediate effect.
+
+5. **Auditability**  
+   Every install, update, activation, and execution is ledgered.
+
+---
+
+## 4. Marketplace Asset Types
+
+The Marketplace may distribute the following governed assets:
+
+1. **CATs**  
+   Reusable, composable AI tasks.
+
+2. **Wrappers / Enhancers**  
+   CAT extensions that add constraints or behavior without loosening governance.
+
+3. **Provider Adapters**  
+   Interfaces to AI providers (must comply with STRICT routing).
+
+4. **Prompt Templates**  
+   Governed templates bound to CAT execution.
+
+5. **Execution Strategies**  
+   Predefined patterns (e.g., batch, staged) that still pass Phase A & B.
+
+Each asset type must declare its **governance surface** explicitly.
+
+---
+
+## 5. Marketplace Registry
+
+All marketplace assets must be registered in the **Marketplace Registry**.
+
+Recommended base path: docs/governance/marketplace/registry/
+
+
+Each asset must have a dedicated folder: docs/governance/marketplace/registry/<ASSET_ID>/
+
+
+The registry is the **authoritative source** for asset identity and state.
+
+---
+
+## 6. Asset Identity & Metadata
+
+Each asset must declare:
+
+- `asset_id` (immutable)
+- `asset_type`
+- `name`
+- `owner` (individual / org)
+- `version`
+- `status` (see lifecycle)
+- `compatible_rgpt_versions`
+- `required_providers` / `required_models`
+- `risk_classification` (R0–R3)
+- `data_sensitivity`
+- `license_terms` (if applicable)
+
+Metadata is **binding** and enforced.
+
+---
+
+## 7. Asset Lifecycle States
+
+Each asset must be in exactly one state:
+
+1. **SUBMITTED**
+2. **UNDER_REVIEW**
+3. **APPROVED**
+4. **ACTIVE**
+5. **SUSPENDED**
+6. **DEPRECATED**
+7. **REVOKED**
+
+State transitions:
+- Require Phase A approval
+- Must be written to the Decision Ledger
+
+---
+
+## 8. Onboarding & Certification
+
+### 8.1 Submission
+Asset owner submits:
+- Metadata
+- Governance declarations
+- Compatibility statements
+
+### 8.2 Review
+Policy checks validate:
+- Governance inheritance
+- Provider/model declarations
+- Risk alignment
+- Security posture
+
+### 8.3 Approval
+Approved assets receive:
+- Certification reference
+- Allowed usage scope
+- Version pinning
+
+### 8.4 Activation
+Only ACTIVE assets may be referenced in approvals.
+
+---
+
+## 9. Versioning Rules
+
+- Versions are immutable once published.
+- Updates require new versions and re-approval.
+- Breaking changes require explicit approval.
+- Auto-updates are prohibited.
+
+---
+
+## 10. Distribution & Access Control
+
+Marketplace distribution must support:
+
+- Organization-level allowlists
+- User-level visibility controls
+- Environment scoping (prod / non-prod)
+- Feature flags (governed)
+
+Access control decisions are recorded in the Decision Ledger.
+
+---
+
+## 11. Revocation & Emergency Controls
+
+The platform must support:
+
+- Immediate suspension of assets
+- Emergency revocation
+- Impact analysis (who/what uses the asset)
+- Forced execution failure for revoked assets
+
+Revocation must:
+- Fail closed
+- Produce governance alerts
+- Be ledgered
+
+---
+
+## 12. Execution Rules for Marketplace Assets
+
+Before execution:
+
+1. Asset must be ACTIVE
+2. Referenced CATs must be ACTIVE
+3. Phase A approval must explicitly allow the asset
+4. Phase B STRICT routing must validate providers/models
+5. Execution must be ledgered
+
+Marketplace assets **never bypass** these steps.
+
+---
+
+## 13. Compliance & Audit
+
+Marketplace must support:
+
+- Full asset lineage
+- Usage tracking
+- Certification history
+- Revocation history
+- Cross-reference with execution ledgers
+
+Missing records constitute audit failure.
+
+---
+
+## 14. Relationship to Other Documents
+
+- **RGPT-ARCH-A.md** — Approval & authority
+- **RGPT-ARCH-B.md** — STRICT routing & execution
+- **RGPT-GOV-LEDGERS.md** — Evidence & immutability
+- **RGPT-GOV-CATS.md** — CAT lifecycle & registry
+
+---
+
+## 15. Completion Note
+
+With this document, **Phase A, Phase B, and Phase C** are architecturally complete.
+
+All future specifications must **conform** to these documents.
+
+---
+
+
+
+

--- a/docs/architecture/cognitive-capability-mesh/CCM-01-overview.md
+++ b/docs/architecture/cognitive-capability-mesh/CCM-01-overview.md
@@ -1,0 +1,47 @@
+# CCM-01 Overview
+
+## Purpose
+Batch-7 introduces the Cognitive Capability Mesh (CCM) as a governed capability expansion layer for the Cognitive Mesh runtime.
+
+The CCM sits between Session Brain control logic and concrete capability adaptors. It enables controlled invocation, standardized contracts, verification handoff, and observable outcomes.
+
+## Problem Solved
+Without CCM, runtime growth would couple the brain directly to raw adaptors, making governance and monitoring difficult. CCM provides:
+- A governed registry of approved capabilities
+- Typed invocation and result envelopes
+- Guardrail-aware invokability checks
+- Verification handoff path
+- Unified runtime recording in session artifacts
+
+## Relationship to Existing Runtime Layers
+- Session Brain: chooses and records cognitive decisions
+- Capabilities/Adaptors: provide bounded functional execution
+- Learner Verification (foundation): validates outputs when required
+- CATS: remains execution layer; not replaced by CCM
+- Consortium Governance: represented by registry metadata and status/risk/verification rules
+
+## High-Level Flow
+1. Runtime receives request and initializes session brain context.
+2. Brain/routing path selects an approved capability.
+3. CCM orchestrator validates invokability via registry status.
+4. Adaptor invocation runs with typed request envelope.
+5. Result envelope returns with confidence/errors/verification flag.
+6. Verification handoff runs when required by guardrails.
+7. Runtime records outcome in working memory, reasoning context, and decision trail.
+8. Session state finalization continues through existing terminal-safe lifecycle.
+
+## Current Scope
+Implemented in Batch-7:
+- Capability taxonomy, registry, status model
+- Request/result/verification contracts
+- Starter capabilities: language, retrieval, verification
+- Capability orchestrator with guardrail checks
+- Runtime integration with session artifact updates
+
+Deferred by design:
+- Adaptive reasoning engine
+- Long-term memory and vector retrieval
+- Autonomous capability creation/approval
+- Broad internet/multimodal capability expansion
+- Persistent/distributed capability mesh infrastructure
+

--- a/docs/architecture/cognitive-capability-mesh/CCM-02-registry-and-contracts.md
+++ b/docs/architecture/cognitive-capability-mesh/CCM-02-registry-and-contracts.md
@@ -1,0 +1,72 @@
+# CCM-02 Registry And Contracts
+
+## Capability Taxonomy
+Capability families:
+- `perception`
+- `knowledge`
+- `action`
+- `assurance`
+
+Every capability definition declares one family.
+
+## Capability Metadata Model
+Core metadata fields:
+- `capabilityId`
+- `name`
+- `family`
+- `version`
+- `status`
+- `description`
+- `ownerAuthority`
+- `allowedOperations`
+- `verificationMode`
+- `riskLevel`
+- `directBrainCommitAllowed`
+- optional monitoring and metadata
+
+This model is implemented in `capability.types.ts`.
+
+## Lifecycle And Status Model
+Supported statuses:
+- `proposed`
+- `approved`
+- `active`
+- `restricted`
+- `suspended`
+- `deprecated`
+- `retired`
+
+Current invokable statuses:
+- `active`
+- `restricted`
+
+Non-invokable statuses are blocked by orchestrator/registry checks.
+
+## Request Envelope Contract
+`CapabilityRequestEnvelope` standardizes brain-to-capability invocation:
+- identity: `requestId`, `sessionId`, `capabilityId`
+- purpose and payload: `purpose`, `input`
+- optional expectations: `expectedOutputType`, `verificationMode`, `priority`
+- constraints and trace: `sourceConstraints`, `trace`
+- timing: `createdAt`
+
+## Result Envelope Contract
+`CapabilityResultEnvelope` standardizes adaptor responses:
+- identity: `requestId`, `sessionId`, `capabilityId`
+- execution status: `success | failed | blocked | unavailable`
+- output and quality: `payload`, `confidence`, `freshness`
+- source and diagnostics: `sourceMetadata`, `warnings`, `errors`
+- governance flag: `verificationRequired`
+- timing/trace: `completedAt`, `trace`
+
+## Verification Handoff Contract
+`VerificationRequestEnvelope` and `VerificationResultEnvelope` define learner handoff:
+- input: original capability result and trace context
+- output: `verdict`, `confidence`, `notes`, `recommendedAction`
+
+Verdict space:
+- `accept`
+- `reject`
+- `escalate`
+- `review`
+

--- a/docs/architecture/cognitive-capability-mesh/CCM-03-starter-capabilities.md
+++ b/docs/architecture/cognitive-capability-mesh/CCM-03-starter-capabilities.md
@@ -1,0 +1,55 @@
+# CCM-03 Starter Capabilities
+
+## Scope
+Batch-7 intentionally implements a small starter set to validate architecture, not capability depth.
+
+Implemented starter capabilities:
+- Language capability
+- Retrieval capability
+- Verification capability
+
+## Language Capability
+ID: `cap.language.v1`
+
+Purpose:
+- normalize text
+- provide lightweight structured language output
+- provide deterministic summary output
+
+Behavior:
+- trims/collapses whitespace
+- returns normalized and summary text
+- low-risk profile, direct brain commit allowed
+
+## Retrieval Capability
+ID: `cap.retrieval.v1`
+
+Purpose:
+- perform controlled retrieval over internal in-memory records
+- provide structured lookup results
+
+Behavior:
+- query-based filtering
+- bounded result set
+- medium-risk profile, verification required, direct commit disallowed
+
+## Verification Capability
+ID: `cap.verification.v1`
+
+Purpose:
+- establish learner-verification handoff contract in runtime
+- validate capability result quality signals
+
+Behavior:
+- consumes verification request envelope
+- produces verdict (`accept/reject/escalate/review`)
+- returns recommendation for commit/escalation path
+
+## Known Limitations
+- Retrieval source is intentionally simple and in-memory.
+- Verification is foundational and deterministic, not a full learner framework.
+- No internet/multimodal/tool-execution capability expansion in this batch.
+
+## Extension Path
+Future capabilities should be onboarded via the same registry + contract + orchestrator model, with explicit governance metadata and verification mode.
+

--- a/docs/architecture/cognitive-capability-mesh/CCM-04-governance-and-guardrails.md
+++ b/docs/architecture/cognitive-capability-mesh/CCM-04-governance-and-guardrails.md
@@ -1,0 +1,44 @@
+# CCM-04 Governance And Guardrails
+
+## Governance Intent
+CCM is designed to be governance-aware from the start. Capability invocation is not free-form.
+
+Key governance inputs modeled in this batch:
+- capability lifecycle status
+- verification mode
+- direct brain commit permission
+- risk metadata
+
+## Guardrails Enforced Now
+1. Invokability by status
+- suspended/retired/etc. are blocked
+- only invokable statuses are accepted by registry/orchestrator
+
+2. Verification requirement
+- capability-level verification mode plus result `verificationRequired` drives verification handoff
+
+3. Direct commit restriction
+- payload commit to session brain is permitted only when:
+  - result status is success
+  - capability allows direct commit
+  - verification outcome (if present) is acceptable
+
+## Guardrail Signals In Runtime Artifacts
+Runtime captures guardrail-relevant outcomes in:
+- reasoning context entries for capability invocation and verification
+- decision trail entries for selection/outcome/verdict
+
+## Restricted / Suspended / Retired Semantics
+- restricted: invokable with stricter verification semantics
+- suspended: not invokable
+- retired: not invokable
+
+## Deferred Governance Work
+Not implemented in Batch-7:
+- full consortium workflow engine
+- policy-as-code execution layer
+- distributed capability approval service
+- persistent governance audit store
+
+These are intentionally deferred; contracts and status fields are in place for later expansion.
+

--- a/docs/architecture/cognitive-capability-mesh/CCM-05-runtime-flow.md
+++ b/docs/architecture/cognitive-capability-mesh/CCM-05-runtime-flow.md
@@ -1,0 +1,48 @@
+# CCM-05 Runtime Flow
+
+## Batch-7 Runtime Integration
+CCM integration in `mesh-live-runtime.ts` is minimal and additive:
+- session brain initialization remains the entrypoint
+- capability invocation is executed through `CapabilityMeshOrchestrator`
+- output is recorded through standardized brain artifacts
+- terminal state safety from Batch-6.1 is preserved
+
+## Invocation Path
+1. Request enters runtime.
+2. Session brain is initialized/fetched and request context recorded.
+3. Runtime creates capability request envelope.
+4. Orchestrator resolves capability metadata and invokability.
+5. Adaptor invocation runs.
+6. Verification handoff runs when required.
+7. Runtime records invocation/verdict in context + decision trail.
+8. Commit behavior is constrained by direct-commit + verification rules.
+9. Normal route execution continues and terminal state finalization occurs.
+
+## Capability Selection
+Current starter flow:
+- chat path defaults to language capability
+- workflow path defaults to retrieval capability
+
+This is intentionally minimal and deterministic.
+
+## Session Artifact Updates
+During capability path:
+- reasoning context:
+  - capability invoked
+  - verification result (when present)
+- decision trail:
+  - capability selection
+  - capability outcome
+  - verification verdict (when present)
+- working memory:
+  - capability payload commit only if guardrails allow
+
+## Success / Failure Behavior
+- Success: flow continues; route outcome finalization still drives terminal `completed`.
+- Capability invocation failure:
+  - `fallback` mode (default): record failure, continue normal route path.
+  - `strict` mode: throw and allow runtime error path to finalize `failed`.
+
+## Why This Is Sufficient For Batch-7
+Batch-7 establishes the governed capability foundation and contracts while keeping runtime behavior stable and low-risk. Adaptive reasoning can build on these contracts later without rewriting core runtime flow.
+

--- a/docs/architecture/cognitive-experience-layer/CEL-01-overview.md
+++ b/docs/architecture/cognitive-experience-layer/CEL-01-overview.md
@@ -1,0 +1,39 @@
+# Cognitive Experience Layer (CEL) Overview
+
+## Purpose
+CEL captures deterministic, governed runtime experience records after execution outcomes are known.
+
+## Problem Solved
+Before CEL, runtime had rich events but no single structured record representing:
+- session situation
+- capability action
+- verification behavior
+- final outcome
+- contextual signals (fallback/guardrail/recovery/confidence)
+
+CEL adds one assembled record per meaningful execution outcome.
+
+## Placement
+Flow:
+1. Session Brain and runtime execute request/workflow.
+2. Capability Mesh invocation and optional verification complete.
+3. Route outcome resolves.
+4. CEL assembles and classifies final experience.
+5. Capture policy decides whether to store.
+6. Meaningful records are stored in bounded in-memory repository.
+
+## What CEL Is Not
+- not adaptive reasoning
+- not a learning engine
+- not vector memory/embeddings
+- not automatic runtime adaptation
+
+## Current Scope
+- strict typed experience contracts
+- deterministic outcome classification
+- circumstantial signal derivation
+- learnable value assessment
+- governed capture policy
+- in-memory repository and retrieval hooks
+- runtime integration in `mesh-live-runtime.ts`
+

--- a/docs/architecture/cognitive-experience-layer/CEL-02-record-and-policy.md
+++ b/docs/architecture/cognitive-experience-layer/CEL-02-record-and-policy.md
@@ -1,0 +1,57 @@
+# CEL Record Model and Capture Policy
+
+## Experience Record Structure
+Each `ExperienceRecord` includes:
+- identity: `experienceId`, `sessionId`, `timestamp`
+- source metadata: component/source/request/event identifiers
+- situation and context
+- action and verification
+- outcome classification and quality metadata
+- circumstantial signals
+- learnable value assessment
+- tags, relevance score, meaningful flag
+
+## Outcome Classification
+Deterministic outcomes:
+- `successful`
+- `successful-with-verification`
+- `successful-with-fallback`
+- `partial`
+- `rejected`
+- `failed`
+- `guarded`
+- `aborted`
+
+Each outcome also has:
+- status (`positive` | `neutral` | `negative`)
+- `reusable`
+- `stabilityImpact`
+- concise summary
+
+## Circumstantial Signals
+CEL derives lightweight context:
+- fallback/guardrail flags
+- verification required/failed
+- capability count signal
+- complexity and fragility flags
+- recovery path and low-confidence markers
+
+## Learnable Value
+`assessLearnableValue()` assigns:
+- level (`high` | `medium` | `low` | `none`)
+- deterministic rationale
+- reusable value boolean
+
+## Capture Policy
+`ExperienceCapturePolicy.shouldCaptureExperience()` produces:
+- `shouldCapture`
+- `relevanceScore` (0..1)
+- policy reasons
+
+Policy intent:
+- suppress trivial successful executions
+- prioritize failed/rejected/guarded/fallback-rich/verification-heavy outcomes
+- keep initial storage meaningful and bounded
+
+Batch-8 operational note:
+- current meaningfulness threshold (`relevanceScore >= 0.45`) is an initial governance policy for Batch-8 and may be tuned in future governed batches.

--- a/docs/architecture/cognitive-experience-layer/CEL-03-runtime-and-governance.md
+++ b/docs/architecture/cognitive-experience-layer/CEL-03-runtime-and-governance.md
@@ -1,0 +1,50 @@
+# CEL Runtime Integration and Governance Boundaries
+
+## Runtime Integration Point
+CEL is invoked in `MeshLiveRuntime` after capability + route outcome resolution:
+- success path captures after route result is recorded
+- failure path captures from exception path
+- capture execution is isolated so CEL failures never break runtime routing
+
+## Session Brain Artifacts
+Runtime writes deterministic capture diagnostics after outcome resolution:
+- working memory:
+  - `runtime.last_experience_capture_status` (`captured` | `skipped` | `failed`)
+  - `runtime.last_experience_capture_error` (nullable diagnostic marker)
+
+When capture is meaningful, runtime also writes:
+- working memory:
+  - `runtime.last_experience_id`
+  - `runtime.last_experience_outcome`
+- reasoning context:
+  - `runtime.experience_captured`
+- decision trail:
+  - `runtime.experience_capture`
+
+## Storage and Retrieval
+Initial storage:
+- bounded in-memory repository (`InMemoryExperienceRepository`)
+
+Retrieval hooks (read-only):
+- recent experiences by session
+- experiences by capability
+- experiences by outcome
+- experiences by circumstantial signals
+
+These hooks are for observability and future extension only; they do not alter runtime decisions in Batch-8.
+
+## Benchmark Scope Clarification
+The Batch-8 capture benchmark is a bounded in-memory sanity guard only. It is not an end-to-end system SLA guarantee.
+
+## Governance Boundaries
+Batch-8 governance rules:
+- capture only meaningful execution outcomes
+- avoid heartbeat/no-op/trivial event capture
+- keep behavior deterministic and explainable
+- no autonomous adaptation from experience data
+
+## Deferred to Future Batches
+- long-term persistence of experiences
+- adaptive capability selection using experience data
+- pattern mining and learning loops
+- ML/embedding/vector retrieval

--- a/docs/architecture/cognitive-mesh-v1-02-live-pipeline.md
+++ b/docs/architecture/cognitive-mesh-v1-02-live-pipeline.md
@@ -1,0 +1,113 @@
+# Cognitive Mesh V1-02 Live Pipeline
+
+## What Is Now Live
+- A minimal deterministic Cognitive Mesh pipeline is active behind `COGNITIVE_MESH_V1_02_LIVE_ENABLED`.
+- Current runtime wiring is intentionally limited to one request entry point:
+  - `GET /api/orchestrator/run/status`
+- This hook is observational/non-breaking: existing response payload and governance behavior are unchanged.
+- As of v1-03, chat path wiring is introduced behind a separate flag:
+  - `COGNITIVE_MESH_V1_03_CHAT_LIVE_ENABLED` on `POST /api/demo/chat`
+
+## Request Lifecycle
+`request hook -> normalize CognitiveEvent -> principal intake -> log -> structural index -> working memory write/read -> reasoning plan -> async dispatch queue`
+
+Detailed flow:
+1. Runtime hook creates an event with source type `workflow.trigger`.
+2. `InputIngestor` normalizes input and assigns baseline trust/risk.
+3. `PrincipalIntakeGuard` assigns disposition (`allow|restrict|quarantine|block`) using deterministic rules.
+4. `MeshRouter` logs event + intake result and starts routing.
+5. Structural index is created with tags:
+   - `source_type`
+   - `project_or_domain` (if metadata is present)
+   - `session_id`
+   - `request_id`
+   - `route_type`
+   - `trust_class`
+6. Allowed events write to bounded TTL working memory and perform session-scoped recall.
+7. Deterministic reasoning plan is generated (cached).
+8. Follow-up tasks are queued for async processing.
+
+## Sync vs Async Work Split
+Sync (request path):
+- normalization
+- intake evaluation
+- minimal logging
+- structural indexing
+- guarded working-memory write/read
+- deterministic plan shell creation
+- async enqueue only
+
+Async (queued follow-up):
+- `deepen-index`
+- `summarize-session`
+- `evaluate-learning-candidate`
+- `quarantine-review` (when relevant)
+
+Workers are safe no-op by default in this phase; queue entries are still observable.
+
+## Trust/Risk Disposition Rules
+- `block`:
+  - explicit blocked trust class
+  - high-risk content patterns (for example `<script`, `drop table`, `rm -rf`)
+- `quarantine`:
+  - explicit quarantined trust class
+  - oversized payloads
+- `restrict`:
+  - `untrusted` or `evidence_only`
+- `allow`:
+  - all remaining low-risk cases
+
+Rule behavior:
+- Only `allow` enters active indexing and working memory.
+- `restrict/quarantine/block` are logged and rejected from active memory/index paths.
+
+## Persistence and Adapters
+- Added repository seam with in-process adapter:
+  - `cog_events`
+  - `cog_logs`
+  - `cog_indexes`
+  - `cog_memory_items`
+  - `cog_reasoning_sessions`
+  - `cog_reasoning_steps`
+- Optional durable JSONL append mode via `COGNITIVE_MESH_DURABLE_JSONL_PATH`.
+- DB integration is intentionally deferred in v1-02 to avoid hot-path query risk.
+
+## Metrics
+Recorded in live pipeline:
+- `mesh_event_received`
+- `mesh_intake_allowed`
+- `mesh_intake_restricted`
+- `mesh_intake_blocked`
+- `mesh_working_memory_write`
+- `mesh_reasoning_plan_created`
+- `mesh_async_dispatch_queued`
+- `mesh_cache_hit`
+
+Foundation metrics also tracked:
+- `plan_latency_ms`
+- `first_response_ms`
+- `cache_hit`
+- `deep_mode_rate`
+- `timeout_rate`
+- `fallback_rate`
+- `improvise_rate`
+
+## Performance Notes
+- Feature flag default is off, so default runtime overhead is zero.
+- In live mode, sync work is in-process and deterministic; no external network calls are added.
+- Hot-path DB queries added by this phase: `0`.
+- Expected request-path overhead budget: low single-digit milliseconds in normal conditions (benchmark guard maintained).
+
+## Current Limitations
+- No CATS runtime hook yet (normalization extension points exist).
+- No embeddings/vector DB/semantic retrieval.
+- No autonomous memory promotion.
+- Async workers are queue placeholders.
+- CAT registry summary cache is not yet wired to CATS runtime in this phase.
+
+## Next Planned Phase (V1-03)
+- Wire chat/user-text path with same deterministic guard-first flow.
+- Wire CATS/task execution path to source type `cats.task_execution`.
+- Add production queue adapter and worker processing.
+- Add repository adapter for actual DB writes with bounded batching.
+- Add CAT registry summary cache integration in the CATS serving path.

--- a/docs/architecture/cognitive-mesh-v1-03-chat-recall-foundation.md
+++ b/docs/architecture/cognitive-mesh-v1-03-chat-recall-foundation.md
@@ -1,0 +1,82 @@
+# Cognitive Mesh V1-03 Chat Recall Foundation
+
+## What Is Now Live In Chat Path
+- Cognitive Mesh is now wired to the primary conversational endpoint:
+  - `POST /api/demo/chat`
+- Wiring is feature-flagged by `COGNITIVE_MESH_V1_03_CHAT_LIVE_ENABLED`.
+- Hook model is non-breaking and fail-safe:
+  - mesh runs as best-effort observation/processing
+  - chat response contract remains unchanged
+  - mesh failures do not fail chat responses
+
+## Bounded Persistence Model
+- Repository seam persists the following entities:
+  - `cog_events`
+  - `cog_logs`
+  - `cog_indexes`
+  - `cog_memory_items`
+  - `cog_reasoning_sessions`
+  - `cog_reasoning_steps`
+- Sync path is bounded to low write count:
+  - synchronous priority writes: event + structural index
+  - additional writes are deferred through async fire-and-forget adapter calls
+- Default live adapter uses durable JSONL append at:
+  - `.rocketgpt/cognitive-mesh/live-pipeline.jsonl`
+- This is a hybrid persistence model; DB-first adapters are deferred.
+
+## Recall Rules
+- Recall is deterministic and bounded.
+- Recall sources:
+  - working memory by session/request
+  - recent related events by source/route/session
+  - recent memory items by session
+- Recall bounds:
+  - item count cap
+  - total recalled text cap
+- No semantic retrieval or embedding search is used.
+
+## Trust-Filtered Memory Behavior
+- Intake disposition gates upstream admission (`allow/restrict/quarantine/block`).
+- Memory guard behavior:
+  - `blocked`/`quarantined`/`untrusted`/`evidence_only` are denied for active memory writes
+  - recall disposition (`allow/restrict/exclude`) controls recall inclusion
+- Restricted/quarantined/blocked items are excluded from active recallable memory.
+
+## Sync vs Async Responsibilities
+Sync:
+- event normalization
+- intake evaluation
+- bounded persistence (priority sync writes)
+- structural indexing
+- guarded working-memory write/read
+- deterministic recall composition
+- deterministic plan enrichment
+- async enqueue
+
+Async:
+- session-summary candidate
+- recall-compaction candidate
+- learning-evaluation candidate
+- quarantine-review candidate
+- deferred persistence writes
+
+## Metrics Added/Extended
+- `mesh_chat_hook_invoked`
+- `mesh_recall_attempted`
+- `mesh_recall_hit`
+- `mesh_recall_filtered`
+- `mesh_repository_write`
+- `mesh_repository_write_deferred`
+- `mesh_reasoning_plan_enriched`
+
+## Current Limitations
+- Primary persistence adapter is durable JSONL/hybrid, not DB-native transactional storage.
+- Recall remains lexical/structural only.
+- CATS runtime path is not yet live-wired.
+- Async workers remain placeholder/no-op by default.
+
+## Deferred Items For V1-04
+- DB-backed repository adapters with explicit batching and retry controls.
+- CATS path hook wiring with same fail-safe guarantees.
+- Recall compaction worker and retention policy enforcement.
+- Operational dashboards for mesh metrics and deferred-write error tracking.

--- a/docs/architecture/cognitive-mesh-v1-foundation.md
+++ b/docs/architecture/cognitive-mesh-v1-foundation.md
@@ -1,0 +1,79 @@
+# Cognitive Mesh V1 Foundation
+
+## Purpose of Cognitive Mesh
+The Cognitive Mesh is RocketGPT's governed intelligence fabric. It provides a controlled lifecycle for sensing input, applying principal guardrails, logging/indexing memory-safe artifacts, planning bounded reasoning, and routing deferred learning/unlearning work to background jobs.
+
+This V1 foundation focuses on stable contracts and service boundaries so future iterations can add deeper intelligence without breaking existing flows.
+
+## Lifecycle
+The target lifecycle is:
+
+`sense -> log -> index -> remember -> think -> decide -> execute -> learn -> unlearn`
+
+Current scaffold mapping:
+
+- `sense`: `sensory/input-ingestor.ts`, `sensory/signal-normalizer.ts`
+- `log`: `logging/cognitive-log-service.ts`
+- `index`: `indexing/index-orchestrator.ts`, `indexing/structural-indexer.ts`
+- `remember`: `memory/*`
+- `think`: `thinking/*`
+- `decide`: `routing/mesh-router.ts` + principal guard decisions
+- `execute`: represented by sync action shell in reasoning plan
+- `learn`: `learning/learning-engine.ts`
+- `unlearn`: `unlearning/archive-manager.ts`
+
+## Principal Guardrails
+Principal guardrails are required before memory/index/learning effects:
+
+- `principal-intake-guard`: first gate for admission or quarantine
+- `principal-memory-guard`: controls memory writes/recall exposure
+- `principal-learning-guard`: controls promotion/retention/archive/reject
+- `risk-scorer` + `trust-classifier`: baseline trust/risk shaping
+- `quarantine-manager`: safe containment seam
+
+These guardrails are intentionally deterministic and low-cost in V1.
+
+## Sync vs Async Split
+Request-path (`sync`) responsibilities:
+
+- normalize and map input to `CognitiveEvent`
+- intake guard evaluation
+- lightweight logging and structural indexing
+- guarded working-memory write
+- minimal reasoning plan shell generation
+- first response shell return with async job references
+
+Background (`async`) responsibilities:
+
+- deep indexing enrichment
+- learning evaluation/promotion workflows
+- archive/unlearning workflows
+- quarantine review processing
+
+This split protects first-response latency and keeps heavy work out of request path.
+
+## Included in V1 Foundation
+- Type-safe contracts for event, memory, index, and reasoning trace.
+- Trust class, risk model, memory tier, processing mode, learning and recall dispositions.
+- Interfaces for intake guard, memory guard, learning guard, log writer, index writer, memory store, memory retriever, reasoning planner, and archive manager.
+- No-op/default implementations for all core services.
+- Session-local memory defaults (no global intelligence writes).
+- Router and job dispatcher seams to separate sync and async responsibilities.
+- Unit + benchmark tests for request-path scaffolding.
+- Initial SQL migration draft for Cognitive Mesh tables.
+
+## V1-02 Live Activation Update (2026-03-06)
+- `MeshRouter` now executes a deterministic minimal live pipeline (`normalize -> intake -> logging -> structural index -> working memory -> plan -> async dispatch`) when a request path explicitly opts in.
+- Runtime wiring is guarded by `COGNITIVE_MESH_V1_02_LIVE_ENABLED` and currently attached only to `/api/orchestrator/run/status`.
+- Live mode remains non-breaking: route responses are unchanged; mesh failures are isolated and non-blocking.
+- Intake now emits explicit dispositions: `allow`, `restrict`, `quarantine`, `block`. Only `allow` proceeds to index/memory writes.
+- Working memory is session-local, bounded, and TTL-based.
+- Plan generation uses deterministic rules plus a lightweight in-process cache; no embeddings/vector retrieval are introduced.
+- Async dispatch now queues concrete task kinds: `deepen-index`, `summarize-session`, `evaluate-learning-candidate`, `quarantine-review`.
+
+## Intentionally Deferred
+- Embeddings/vector database integration.
+- Semantic memory extraction and retrieval ranking.
+- Autonomous or provider-specific learning logic.
+- External queue or storage provider integrations.
+- Any change to existing governance gate behavior outside hook-based integration points.

--- a/docs/architecture/cognitive-mesh/CM-01-overview.md
+++ b/docs/architecture/cognitive-mesh/CM-01-overview.md
@@ -1,0 +1,220 @@
+# RocketGPT Cognitive Mesh - System Overview
+
+**Document ID:** CM-01  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose of Cognitive Mesh
+
+The Cognitive Mesh is RocketGPT's distributed intelligence layer responsible for secure knowledge exchange, governed learning, and cross-domain reasoning at runtime. It standardizes how knowledge is created, validated, routed, consumed, and promoted across autonomous and human-supervised components.
+
+The mesh exists to:
+
+- decouple intelligence generation from intelligence execution;
+- enable low-latency knowledge propagation across services and agents;
+- enforce governance, trust, and audit constraints on all learning flows;
+- preserve explainability through evidence-linked decision artifacts.
+
+The Cognitive Mesh is not a user-facing feature. It is a control-plane and data-plane architecture for intelligence lifecycle management.
+
+## 2. Why RocketGPT Uses a Distributed Intelligence Mesh
+
+RocketGPT operates in multi-tenant, high-variance environments where static monolithic intelligence is insufficient. A distributed mesh is required to support parallel experts, domain-local learning, and policy-constrained adaptation without central bottlenecks.
+
+Primary drivers:
+
+- domain specialization: distinct experts and learners optimize for different problem classes;
+- resilience: node-level degradation does not collapse platform intelligence;
+- scale: concurrent sessions can consume and produce knowledge independently;
+- governance compatibility: evidence, policy checks, and promotion controls can be applied per packet and per hop;
+- velocity: new learnings can propagate quickly without full system redeployments.
+
+## 3. Key Principles
+
+### 3.1 Distributed Intelligence
+
+Intelligence is partitioned across specialized components (experts, learners, libraries, execution engines). No single node is assumed to be complete or globally authoritative for all tasks.
+
+### 3.2 Knowledge Propagation
+
+Knowledge is exchanged as structured, signed packets with explicit provenance and scope. Propagation is selective, policy-aware, and latency-bounded.
+
+### 3.3 Governed Learning
+
+All learning events are evaluated by governance gates before becoming reusable system knowledge. Learning can be session-local by default and only promoted when explicitly approved.
+
+### 3.4 Zero-Trust Messaging
+
+Every sender, packet, and tunnel interaction is authenticated and authorized. Trust is established through cryptographic identity, policy checks, and runtime verification, not network location.
+
+### 3.5 Evidence-Driven Reputation
+
+Reputation scores for experts, learners, and packets are computed from observed outcomes and linked evidence. Assertions without evidence cannot accumulate durable trust.
+
+## 4. Core Subsystems
+
+### 4.1 Knowledge Packet Protocol (KPP)
+
+Defines canonical packet structure for cognitive exchange:
+
+- envelope: packet ID, sender ID, tenant/session scope, timestamp, signature;
+- payload: claims, recommendations, artifacts, confidence bands;
+- evidence references: logs, traces, evaluation outputs, source pointers;
+- governance fields: policy tags, sensitivity level, retention class, promotion eligibility.
+
+Responsibilities:
+
+- serialization and schema evolution;
+- integrity and provenance guarantees;
+- replay-safe identifiers and idempotency.
+
+### 4.2 Messenger Tunnels
+
+Secure transport channels between mesh participants. Tunnels provide encrypted, authenticated message delivery with backpressure and delivery telemetry.
+
+Responsibilities:
+
+- mTLS or equivalent authenticated transport;
+- ordered or causal delivery semantics per route class;
+- retry, dead-letter, and timeout handling;
+- tunnel-level observability.
+
+### 4.3 Mesh Router
+
+Policy-aware routing fabric that decides packet destinations and priority based on intent, context, trust posture, and SLA class.
+
+Responsibilities:
+
+- topic and capability-based routing;
+- tenant/session isolation enforcement;
+- adaptive fan-out/fan-in;
+- load-aware and failure-aware path selection.
+
+### 4.4 Knowledge Libraries (EKL / IKL / SIL)
+
+Structured knowledge stores with distinct trust and lifecycle boundaries:
+
+- **EKL (External Knowledge Library):** validated external references, standards, and imported domain intelligence.
+- **IKL (Internal Knowledge Library):** organization-specific operational and experiential knowledge.
+- **SIL (Signal Intelligence Layer):** short-lived intelligence signals used for routing hints, emerging observations, and transient reasoning artifacts.
+
+Responsibilities:
+
+- scoped retrieval and retention policies;
+- versioning and provenance indexing;
+- controlled promotion paths (SIL -> IKL/EKL).
+
+### 4.5 Learners
+
+Runtime and batch learning components that convert outcomes into candidate improvements (prompts, strategies, heuristics, plans, routing preferences).
+
+Responsibilities:
+
+- extract signals from execution telemetry and outcomes;
+- generate candidate deltas with confidence estimates;
+- emit promotion requests with evidence bundles;
+- preserve session isolation unless promoted.
+
+### 4.6 CATS Execution Engine
+
+Primary execution runtime that consumes mesh knowledge for task planning and action selection. CATS acts as both consumer and producer within the mesh.
+
+Responsibilities:
+
+- query mesh for task-relevant knowledge;
+- execute plans under governance constraints;
+- publish outcomes and feedback packets for learners and reputation.
+
+### 4.7 Expert Consortium
+
+Federated set of expert agents/services providing domain-specialized reasoning and recommendations.
+
+Responsibilities:
+
+- adjudicate competing hypotheses;
+- return evidence-attached recommendations;
+- participate in consensus and conflict resolution workflows.
+
+### 4.8 Reputation Engine
+
+Computes evidence-driven Learner Ratings and aggregated Learner Reputation profiles, plus reputation signals for experts and knowledge artifacts, using observed effectiveness and governance compliance.
+
+Responsibilities:
+
+- maintain evidence-linked scoring models;
+- update confidence priors for routing and selection;
+- penalize low-quality or non-compliant contributions;
+- surface explainable reputation traces for audits.
+
+## 5. Cognitive Mesh Architecture Diagram
+
+```mermaid
+flowchart LR
+    CATS[CATS Execution Engine] -->|query/publish via KPP| Router[Mesh Router]
+    Experts[Expert Consortium] -->|recommendations| Router
+    Learners[Learners] -->|candidate learnings| Router
+    Router -->|secure transport| Tunnels[Messenger Tunnels]
+    Tunnels --> KPP[Knowledge Packet Protocol]
+    KPP --> EKL[EKL]
+    KPP --> IKL[IKL]
+    KPP --> SIL[SIL]
+    Router --> Rep[Reputation Engine]
+    Rep --> Router
+    Router --> Gov[Governance Gates]
+    Gov -->|allow/deny/promote| EKL
+    Gov -->|allow/deny/promote| IKL
+    Gov -->|session-only| SIL
+    PAGE[PAGE Runtime] --> Router
+```
+
+## 6. Relationship with CATS, Governance, and PAGE
+
+### CATS Integration
+
+CATS is the execution substrate that operationalizes mesh intelligence. It requests guidance from the mesh, executes bounded plans, and returns outcome evidence. The mesh improves CATS quality over time while CATS provides continuous feedback signals to the mesh.
+
+### Governance Integration
+
+Governance gates are authoritative controls over learning acceptance, policy compliance, retention, and promotion. The Cognitive Mesh must integrate governance through hooks and must not bypass existing gate behavior.
+
+### PAGE Integration
+
+PAGE consumes mesh outputs for presentation, interaction orchestration, and user-facing explainability artifacts. PAGE does not replace mesh governance; it surfaces governed intelligence to end-user experiences.
+
+## 7. Design Goals
+
+### 7.1 Millisecond Knowledge Propagation
+
+The mesh targets low-latency packet distribution for high-value updates, with bounded queuing, route prioritization, and fast-path cache utilization where applicable.
+
+### 7.2 Governed Learning
+
+Learning is continuous but never unrestricted. Every reusable improvement requires policy evaluation, evidence linkage, and scope-aware promotion controls.
+
+### 7.3 Self-Evolving Intelligence
+
+The mesh enables iterative improvement from real outcomes through closed feedback loops among CATS, Learners, Experts, and Reputation Engine.
+
+### 7.4 Auditability
+
+Every significant decision path, promotion event, and trust update is traceable to packet lineage, evidence, and policy outcomes.
+
+---
+
+## Non-Functional Expectations
+
+- response shell or first stream chunk within platform latency SLOs;
+- strong tenant/session isolation for improvise intelligence by default;
+- transparent metrics across propagation, learning, fallback, and timeout paths;
+- deterministic replay support for governance and incident audits.
+
+## Glossary
+
+- **SIL - Signal Intelligence Layer**  
+  Short-lived intelligence signals used for routing hints, emerging observations, and transient reasoning artifacts. Signals may later be promoted to IKL.
+- **Learner Rating**  
+  External outcome-driven score used for reputation.
+- **Learner Reputation**  
+  Aggregated historical Learner Rating profile.
+

--- a/docs/architecture/cognitive-mesh/CM-02-knowledge-packet-protocol.md
+++ b/docs/architecture/cognitive-mesh/CM-02-knowledge-packet-protocol.md
@@ -1,0 +1,263 @@
+# Knowledge Packet Protocol (KPP)
+
+**Document ID:** CM-02  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Concept of Knowledge Packets
+
+Knowledge Packet Protocol (KPP) is the canonical message contract for exchanging intelligence within the RocketGPT Cognitive Mesh. A knowledge packet is a cryptographically attributable unit of cognition that carries claims, evidence, directives, or outcomes between trusted-but-verified participants.
+
+KPP is designed for:
+
+- uniform interoperability across mesh subsystems;
+- policy-aware routing and processing;
+- low-latency propagation with deterministic validation;
+- end-to-end auditability under Zero-Trust assumptions.
+
+## 2. Packet Envelope Structure
+
+The envelope contains immutable transport and trust metadata used for authentication, authorization, routing, replay defense, and observability.
+
+Envelope sections:
+
+- `identity`: sender identity, tenant scope, session scope, actor class;
+- `timing`: creation time, expiration time, TTL budget;
+- `routing`: topic family, priority class, intended recipients, hop policy;
+- `security`: signature, key reference, hash algorithm, nonce;
+- `trace`: trace ID, span ID, parent packet ID, correlation ID;
+- `governance`: policy tags, data classification, retention class.
+
+## 3. Packet Payload Structure
+
+The payload contains the semantic knowledge object being exchanged. Payload content is packet-family specific but follows a standard shape.
+
+Payload sections:
+
+- `summary`: short machine- and human-readable intent statement;
+- `claims`: assertions, recommendations, or changes;
+- `evidence`: references and confidence support;
+- `context`: bounded execution/task/session context;
+- `actions`: optional execution hints or directives;
+- `outcomes`: optional observed result metrics;
+- `attachments`: optional compact embedded artifacts.
+
+## 4. Required Fields
+
+The following fields are mandatory for every KPP packet:
+
+- `kpp_version`
+- `packet_id`
+- `packet_family`
+- `created_at`
+- `expires_at`
+- `tenant_id`
+- `session_id` (use `"global"` only for explicitly allowed non-session packets)
+- `sender.id`
+- `sender.type`
+- `trace.trace_id`
+- `routing.topic`
+- `governance.policy_tags` (at least one tag)
+- `integrity.payload_hash`
+- `integrity.signature`
+- `integrity.key_id`
+- `payload.summary`
+
+Packets missing required fields are invalid and must be rejected before routing.
+
+## 5. Packet Families
+
+### 5.1 `knowledge.signal`
+
+Low-cost, high-frequency signal describing event observations or weak hypotheses.
+
+Use cases:
+
+- runtime hints;
+- anomaly or drift alerts;
+- soft confidence updates.
+
+### 5.2 `knowledge.bundle`
+
+Aggregated and evidence-rich packet containing structured knowledge collections.
+
+Use cases:
+
+- expert recommendations;
+- consolidated retrieval outputs;
+- cross-source evidence sets.
+
+### 5.3 `knowledge.delta`
+
+Change-set packet proposing modifications to prompts, strategies, routing priors, or library entries.
+
+Use cases:
+
+- learner-generated improvements;
+- reputation-weighted parameter adjustments;
+- scoped optimization updates.
+
+### 5.4 `knowledge.directive`
+
+Governance- or control-plane directive requiring explicit handling behavior.
+
+Use cases:
+
+- promotion/rollback commands;
+- quarantine or denylist actions;
+- policy override instructions with authority proof.
+
+### 5.5 `knowledge.receipt`
+
+Acknowledgement packet confirming validation, acceptance, rejection, or processing outcome.
+
+Use cases:
+
+- delivery acknowledgements;
+- governance decision responses;
+- replay-safe processing receipts.
+
+## 6. Packet Lifecycle
+
+1. **Construct**: producer composes packet with required envelope/payload fields.  
+2. **Sign**: producer computes payload hash and cryptographic signature.  
+3. **Validate (ingress)**: receiver or edge gateway validates schema, signature, scope, TTL, and policy prerequisites.  
+4. **Route**: mesh router dispatches packet according to topic/capability/policy.  
+5. **Process**: destination subsystem executes family-specific handlers.  
+6. **Emit receipt**: destination emits `knowledge.receipt` with status and evidence pointers.  
+7. **Persist/Audit**: packet metadata and lineage events are recorded according to retention policy.  
+8. **Expire/Archive**: packet becomes ineligible after TTL or retention cutoff.
+
+## 7. Packet Versioning Rules
+
+KPP uses semantic versioning in `kpp_version` (`MAJOR.MINOR.PATCH`).
+
+- `PATCH`: non-breaking clarifications and optional metadata additions.
+- `MINOR`: backward-compatible field additions and new optional families.
+- `MAJOR`: breaking changes to required fields, semantics, or validation behavior.
+
+Compatibility rules:
+
+- receivers must reject unknown major versions;
+- receivers must ignore unknown optional fields for supported major versions;
+- senders must not remove required fields without major bump;
+- schema registry must retain at least two previous minor versions for replay support.
+
+## 8. Packet Size and Performance Constraints
+
+Baseline constraints:
+
+- target packet size: <= 16 KB for hot-path packets;
+- hard packet size limit: 64 KB (larger payloads must use external artifact references);
+- envelope validation budget: <= 2 ms p95;
+- end-to-end route + first processing budget: <= 50 ms p95 for priority classes `P0`/`P1`.
+
+Performance rules:
+
+- compress payload only above configured threshold;
+- avoid binary blobs in-line on latency-sensitive routes;
+- use content-addressable attachment references for large evidence artifacts.
+
+## 9. Packet Transport Rules
+
+- all transport channels must be authenticated and encrypted (mTLS or equivalent);
+- every hop must re-validate authorization against tenant/session scope;
+- no implicit trust based on network boundary;
+- at-least-once delivery is default; idempotency is required for handlers;
+- out-of-order tolerance must be explicit per topic;
+- dead-letter queues must preserve full envelope + integrity metadata.
+
+## 10. Packet Integrity and Traceability
+
+Integrity requirements:
+
+- canonical JSON serialization prior to hashing/signing;
+- `payload_hash` calculated over canonical payload bytes;
+- detached or embedded signature accepted only with approved algorithms;
+- key rotation supported via `key_id` and trust-chain validation.
+
+Traceability requirements:
+
+- each packet must have globally unique `packet_id`;
+- lineage links: `parent_packet_id`, `caused_by`, and `correlation_id`;
+- all validation, routing, and processing decisions must emit audit events;
+- receipts must include disposition (`accepted`, `rejected`, `deferred`, `quarantined`) and reason code.
+
+## 11. Sample Packet Schema (JSON)
+
+```json
+{
+  "kpp_version": "1.0.0",
+  "packet_id": "kp_01JZ9P3T8Q4C6M7N2B5D1R8F4A",
+  "packet_family": "knowledge.bundle",
+  "created_at": "2026-03-06T10:15:21.123Z",
+  "expires_at": "2026-03-06T10:20:21.123Z",
+  "tenant_id": "tenant_acme",
+  "session_id": "sess_6f9f2f03c85d",
+  "routing": {
+    "topic": "cats.plan.enrichment",
+    "priority": "P1",
+    "recipients": ["mesh-router", "cats-exec"],
+    "max_hops": 4
+  },
+  "sender": {
+    "id": "expert.finance.v2",
+    "type": "expert",
+    "instance_id": "exp-fin-07"
+  },
+  "trace": {
+    "trace_id": "trc_4fa9f58df5d24718ad67",
+    "span_id": "spn_92b0f611",
+    "parent_packet_id": "kp_01JZ9P3FQ3S8AA2ZD4K77N3DCD",
+    "correlation_id": "corr_plan_8892"
+  },
+  "governance": {
+    "policy_tags": ["tenant-scoped", "evidence-required", "no-global-promote"],
+    "classification": "internal",
+    "retention_class": "audit-30d",
+    "promotion_eligible": false
+  },
+  "payload": {
+    "summary": "Bundle of ranked plan alternatives with evidence links.",
+    "claims": [
+      {
+        "id": "claim_1",
+        "type": "recommendation",
+        "statement": "Use retrieval-first strategy before synthesis.",
+        "confidence": 0.87
+      }
+    ],
+    "evidence": [
+      {
+        "evidence_id": "ev_101",
+        "kind": "benchmark",
+        "ref": "ikl://benchmarks/plan_latency/run-2031",
+        "weight": 0.72
+      }
+    ],
+    "context": {
+      "task_type": "plan_generation",
+      "constraints": ["latency-p95-<500ms", "governance-gates-required"]
+    }
+  },
+  "integrity": {
+    "alg": "ed25519",
+    "payload_hash": "sha256:5f1f6e1694f8f7f6f2f2f9f0fcb1a1edb6ff95d40cb7d19cc5ea0f6f34ce3ad4",
+    "signature": "base64:QkM4d2xW...snip...",
+    "key_id": "kid_mesh_expert_finance_2026q1",
+    "nonce": "n_8bcd8fd1fca9"
+  }
+}
+```
+
+## Related Specifications
+
+- [CM-03 Messenger Tunnel Architecture](./CM-03-messenger-tunnel-architecture.md)
+- [CM-05 Zero-Trust Messaging Architecture](./CM-05-zero-trust-messaging.md)
+- [CM-15 Knowledge Packet Ledger](./CM-15-knowledge-packet-ledger.md)
+
+## Zero-Trust Compatibility Statement
+
+KPP is Zero-Trust compatible by design. Every packet is self-describing for identity, scope, integrity, and governance context, allowing each mesh hop to perform independent verification and policy enforcement before accepting or forwarding content.
+

--- a/docs/architecture/cognitive-mesh/CM-03-messenger-tunnel-architecture.md
+++ b/docs/architecture/cognitive-mesh/CM-03-messenger-tunnel-architecture.md
@@ -1,0 +1,248 @@
+# Messenger Tunnel Architecture
+
+**Document ID:** CM-03  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Concept of Messenger Tunnels
+
+Messenger Tunnels are the secure transport fabric for Knowledge Packet Protocol (KPP) traffic inside the RocketGPT Cognitive Mesh. A tunnel is a policy-bound, encrypted delivery channel with deterministic handling rules for latency, durability, ordering, and replay behavior.
+
+Messenger Tunnels provide:
+
+- authenticated point-to-point and fan-out delivery;
+- class-based QoS and SLA enforcement;
+- loss-aware acknowledgement and retry controls;
+- lineage-preserving replay and repair capability.
+
+## 2. Tunnel Classes
+
+### 2.1 T0 FastPulse
+
+Ultra-low-latency channel for high-priority, small packets.
+
+- intended traffic: `knowledge.signal`, critical `knowledge.directive`
+- packet profile: compact, no large attachments
+- delivery mode: low queue depth, aggressive expiry
+- target outcome: minimal propagation delay
+
+### 2.2 T1 Standard
+
+Default balanced tunnel for most packet flows.
+
+- intended traffic: general `knowledge.bundle`, `knowledge.receipt`
+- packet profile: moderate size, normal processing
+- delivery mode: durable queue with bounded retries
+- target outcome: stable throughput with low error rate
+
+### 2.3 T2 Heavy
+
+High-capacity tunnel for larger, compute-linked packets.
+
+- intended traffic: large `knowledge.bundle`, `knowledge.delta`
+- packet profile: bigger payloads or attachment references
+- delivery mode: stronger backpressure and staged dispatch
+- target outcome: reliability under load
+
+### 2.4 T3 Replay
+
+Specialized tunnel for recovery, audit replay, and deterministic reprocessing.
+
+- intended traffic: replayed packets, repair directives, historical receipts
+- packet profile: lineage-rich packets with replay markers
+- delivery mode: ordered, checkpointed, replay-safe
+- target outcome: correctness and traceability over raw speed
+
+## 3. Tunnel Pipeline
+
+Canonical flow:
+
+`producer -> packet shaper -> Zero-Trust gate -> dedup -> router -> tunnel -> target`
+
+Stage responsibilities:
+
+- `producer`: emits KPP packet with signature and scope.
+- `packet shaper`: enforces class limits, canonical metadata, and priority mapping.
+- `Zero-Trust gate`: verifies identity, signature, scope, and policy preconditions.
+- `dedup`: drops duplicates using packet ID + nonce + time window.
+- `router`: selects destination(s), tunnel class, and failover path.
+- `tunnel`: executes class-specific delivery semantics.
+- `target`: validates again, processes packet, emits receipt.
+
+## 4. Tunnel Redundancy Models
+
+### 4.1 Active-Active
+
+Two or more live tunnel instances carry traffic simultaneously.
+
+- benefits: low failover latency, load sharing
+- requirements: strict dedup and idempotent targets
+- recommended for: T0 and T1 critical paths
+
+### 4.2 Active-Passive
+
+Primary tunnel handles traffic; secondary remains warm standby.
+
+- benefits: operational simplicity, predictable ordering
+- tradeoff: higher failover switch time
+- recommended for: lower-churn or sensitive ordered streams
+
+### 4.3 Replay Tunnel
+
+Dedicated redundancy path using T3 for missed, quarantined, or corrected traffic.
+
+- benefits: deterministic repair without disrupting live channels
+- requirements: checkpoint ledger and replay authorization
+- recommended for: governance/audit-sensitive flows
+
+## 5. Failure Recovery
+
+Failure handling sequence:
+
+1. detect: timeout, NACK, queue stall, integrity failure, or policy rejection.
+2. classify: transient transport, persistent endpoint, malformed packet, or unauthorized sender.
+3. recover:
+   - transient: bounded retry with exponential backoff;
+   - endpoint failure: failover to alternate active/passive path;
+   - malformed or unauthorized: quarantine and emit reject receipt;
+   - suspected loss: enqueue replay candidate in T3.
+4. reconcile: compare receipts to expected delivery set.
+5. close: emit final status event for observability and governance audit.
+
+## 6. SLA Classes
+
+SLA is enforced by tunnel class and priority policy.
+
+- `SLA-P0` (critical control): target p95 delivery <= 20 ms, very low loss tolerance.
+- `SLA-P1` (interactive intelligence): target p95 delivery <= 50 ms.
+- `SLA-P2` (standard background): target p95 delivery <= 200 ms.
+- `SLA-P3` (replay/audit): latency-tolerant, correctness-first.
+
+SLA conformance is measured end-to-end from accepted producer ingress to target acknowledgement.
+
+## 7. Observability Metrics
+
+Required tunnel metrics:
+
+- `tunnel_ingress_rate`
+- `tunnel_egress_rate`
+- `tunnel_queue_depth`
+- `tunnel_delivery_latency_ms` (p50/p95/p99)
+- `tunnel_ack_latency_ms`
+- `tunnel_drop_rate`
+- `tunnel_retry_rate`
+- `tunnel_failover_count`
+- `tunnel_dedup_drop_count`
+- `tunnel_quarantine_count`
+- `tunnel_replay_backlog`
+- `tunnel_replay_success_rate`
+
+Metrics must be broken down by tunnel class (`T0`-`T3`), tenant, and packet family.
+
+## 8. Packet Acknowledgement System
+
+Every accepted packet requires an acknowledgement flow based on delivery policy:
+
+- `ACK_ACCEPTED`: packet validated and queued by target.
+- `ACK_PROCESSED`: packet handler completed successfully.
+- `ACK_REJECTED`: validation or policy failure with reason code.
+- `ACK_DEFERRED`: accepted but delayed due to dependency/backpressure.
+
+Acknowledgement rules:
+
+- acknowledgements are emitted as `knowledge.receipt` packets;
+- receipt must include original `packet_id`, disposition, timestamp, and signer;
+- missing acknowledgement beyond class timeout triggers retry or replay path;
+- duplicate acknowledgements are tolerated but correlated by receipt ID.
+
+## 9. Replay and Repair System
+
+Replay and repair provide deterministic correction for dropped, late, or invalid processing outcomes.
+
+Core components:
+
+- replay ledger: immutable record of packet lineage, receipts, and checkpoints;
+- repair planner: identifies gaps between expected and observed state;
+- replay executor (T3): reissues packets with replay markers and bounded scope;
+- reconciliation engine: verifies repaired outcomes and closes incidents.
+
+Replay rules:
+
+- only authorized actors can initiate replay directives;
+- replay packets must carry `replay_of_packet_id` and `replay_reason`;
+- replay cannot bypass Zero-Trust gate or governance checks;
+- repaired packets produce new receipts linked to prior failed attempts.
+
+## Architecture Diagrams
+
+### A. End-to-End Tunnel Pipeline
+
+```mermaid
+flowchart LR
+    P[Producer] --> S[Packet Shaper]
+    S --> Z[Zero-Trust Gate]
+    Z --> D[Dedup]
+    D --> R[Mesh Router]
+    R --> T[Tunnel Class Selector]
+    T --> T0[T0 FastPulse]
+    T --> T1[T1 Standard]
+    T --> T2[T2 Heavy]
+    T --> T3[T3 Replay]
+    T0 --> X[Target]
+    T1 --> X
+    T2 --> X
+    T3 --> X
+    X --> A[knowledge.receipt ACK/NACK]
+    A --> R
+```
+
+### B. Redundancy and Recovery Topology
+
+```mermaid
+flowchart TB
+    R[Mesh Router] --> AA1[T0/T1 Active A]
+    R --> AA2[T0/T1 Active B]
+    R --> AP1[T2 Active]
+    AP1 -. failover .-> AP2[T2 Passive]
+    AA1 --> TargetA[Targets]
+    AA2 --> TargetA
+    AP1 --> TargetA
+    AP2 --> TargetA
+    R --> T3[T3 Replay Tunnel]
+    T3 --> TargetA
+    TargetA --> L[Replay Ledger]
+    L --> T3
+```
+
+### C. Replay and Repair Loop
+
+```mermaid
+sequenceDiagram
+    participant O as Observability
+    participant RP as Repair Planner
+    participant RL as Replay Ledger
+    participant T3 as T3 Replay Tunnel
+    participant TG as Target
+    participant RE as Reconciliation Engine
+
+    O->>RP: Detect missing/failed receipt
+    RP->>RL: Query lineage and gap window
+    RL-->>RP: Candidate packet set
+    RP->>T3: Emit replay directive + packet refs
+    T3->>TG: Replayed packet(s)
+    TG-->>T3: knowledge.receipt
+    T3->>RL: Append replay outcome
+    RL->>RE: Provide before/after state
+    RE-->>O: Repair status and closure
+```
+
+## Related Specifications
+
+- [CM-06 Deduplication and Redundancy Architecture](./CM-06-deduplication-redundancy.md)
+- [CM-15 Knowledge Packet Ledger](./CM-15-knowledge-packet-ledger.md)
+
+## Zero-Trust Compatibility Statement
+
+Messenger Tunnels are Zero-Trust by default. Each stage enforces independent verification of identity, signature, tenant/session authorization, and policy compliance. No packet may transit or replay without passing Zero-Trust gate validation and subsequent target-side revalidation.
+

--- a/docs/architecture/cognitive-mesh/CM-04-dual-delivery-routing.md
+++ b/docs/architecture/cognitive-mesh/CM-04-dual-delivery-routing.md
@@ -1,0 +1,175 @@
+# Dual Delivery Routing
+
+**Document ID:** CM-04  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Why Dual Delivery Is Required
+
+Cognitive Mesh packets often need concurrent handling by different subsystem roles to satisfy latency, learning, and governance goals in the same execution window. Single-path delivery introduces avoidable delays and can force unnecessary sequencing between consumers that are logically independent.
+
+Dual delivery is required to:
+
+- support parallel intelligence consumption and learning extraction;
+- prevent critical-path blocking when one consumer is non-critical;
+- preserve evidence consistency across operational and learning planes;
+- reduce total time-to-utility for newly produced knowledge.
+
+## 2. Split Horizon Routing
+
+Split horizon routing is the policy-driven branching of a single validated packet into multiple destination horizons, each with independent delivery semantics and authorization checks.
+
+Horizons:
+
+- **Operational horizon:** low-latency consumers (for immediate execution impact).
+- **Learning horizon:** analysis/optimization consumers (for future improvements).
+- **Control horizon:** governance/router/control components (for enforcement and orchestration).
+
+Routing rules:
+
+- branch creation occurs only after ingress validation;
+- each branch receives the same logical packet identity with branch-specific metadata;
+- branch SLA, retry, and receipt behavior are independently configured;
+- failure in one branch does not automatically fail all branches unless policy requires all-ack.
+
+## 3. Librarian vs Learner Delivery
+
+### Librarian Delivery
+
+Librarian targets (EKL/IKL/SIL-facing services) prioritize indexing, retention policy, provenance, and retrieval readiness.
+
+- objective: durable knowledge placement;
+- typical packets: `knowledge.bundle`, curated `knowledge.delta`;
+- priority: consistency and lineage correctness.
+
+### Learner Delivery
+
+Learner targets prioritize signal extraction, pattern detection, and candidate improvement generation.
+
+- objective: adaptive intelligence;
+- typical packets: `knowledge.signal`, outcome-linked `knowledge.bundle`;
+- priority: rapid feature extraction and feedback loop throughput.
+
+Dual delivery to librarian and learner ensures immediate archival/retrieval value and parallel adaptation value from the same event.
+
+## 4. Routing Patterns
+
+### 4.1 Librarian + Learner
+
+Packet is branched to both storage/indexing and adaptive learning consumers.
+
+- use when packet has reusable evidence and optimization potential;
+- common for high-quality `knowledge.bundle` and post-execution outcomes.
+
+### 4.2 Librarian + Router
+
+Packet is delivered to librarian for persistence and router/control for immediate distribution decisions.
+
+- use when packet influences routing priors or policy posture;
+- common for trust/reputation updates and directives requiring durability.
+
+### 4.3 Learner + Router
+
+Packet is delivered to learner for model/strategy adaptation and router for near-term traffic shaping.
+
+- use when packet is high-signal but not yet archival-grade;
+- common for drift signals, fallback spikes, latency anomalies.
+
+### 4.4 Triple Delivery
+
+Packet is branched concurrently to librarian, learner, and router/control.
+
+- use for high-impact packets with immediate, adaptive, and durable value;
+- requires stricter branch authorization and all-branch observability.
+
+## 5. Branch Authorization Under Zero-Trust
+
+Each branch is independently authorized even when originating from the same packet.
+
+Authorization requirements:
+
+- branch target must validate sender identity and signature;
+- branch policy must verify tenant/session scope compatibility;
+- branch purpose binding must match packet family and governance tags;
+- least-privilege routing: unauthorized branches are dropped, not downgraded;
+- branch decisions must emit audit events with reason codes.
+
+Zero-Trust rule: packet validity at ingress does not imply branch-level entitlement.
+
+## 6. Performance Considerations
+
+Dual/triple delivery must preserve bounded latency for operational paths.
+
+Performance controls:
+
+- prioritize operational branch on low-latency tunnel class (for example T0/T1);
+- dispatch non-critical branches asynchronously to avoid head-of-line blocking;
+- use shared packet body with branch metadata overlays to minimize copy cost;
+- enforce per-branch queue budgets and backpressure;
+- use branch-specific acknowledgement timeouts and retry policies;
+- collapse duplicate branch work via dedup keys when targets overlap functionally.
+
+Recommended behavior:
+
+- soft-fail non-critical branches when policy allows;
+- require all-branch success only for explicitly marked governance-critical packets.
+
+## 7. Example Routing Scenarios
+
+### Scenario A: Execution Outcome Packet
+
+- packet family: `knowledge.bundle`
+- routing pattern: librarian + learner
+- reason: store evidence-rich result while extracting improvement candidates in parallel.
+
+### Scenario B: Routing Drift Alert
+
+- packet family: `knowledge.signal`
+- routing pattern: learner + router
+- reason: adapt future decisions and adjust routing priors immediately.
+
+### Scenario C: Promotion Directive
+
+- packet family: `knowledge.directive`
+- routing pattern: librarian + router
+- reason: durable governance record plus immediate enforcement.
+
+### Scenario D: High-Value Incident Bundle
+
+- packet family: `knowledge.bundle`
+- routing pattern: triple delivery
+- reason: immediate control action, learner adaptation, and archival traceability together.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    P[Validated KPP Packet] --> SR[Split Horizon Router]
+    SR --> B1[Branch: Librarian]
+    SR --> B2[Branch: Learner]
+    SR --> B3[Branch: Router/Control]
+
+    B1 --> Z1[Branch AuthZ + Policy]
+    B2 --> Z2[Branch AuthZ + Policy]
+    B3 --> Z3[Branch AuthZ + Policy]
+
+    Z1 --> L[Librarian Services]
+    Z2 --> N[Learner Services]
+    Z3 --> R[Router/Control Services]
+
+    L --> A1[Receipt]
+    N --> A2[Receipt]
+    R --> A3[Receipt]
+```
+
+## Compliance Notes
+
+- All branches must preserve packet lineage identifiers.
+- Branch receipts must map to original `packet_id` plus `branch_id`.
+- Unauthorized branches must be rejected with auditable disposition.
+
+## Related Specifications
+
+- [CM-07 Mesh Router](./CM-07-mesh-router.md)
+

--- a/docs/architecture/cognitive-mesh/CM-05-zero-trust-messaging.md
+++ b/docs/architecture/cognitive-mesh/CM-05-zero-trust-messaging.md
@@ -1,0 +1,154 @@
+# Zero-Trust Messaging Architecture
+
+**Document ID:** CM-05  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Zero-Trust Principles
+
+RocketGPT Cognitive Mesh messaging follows Zero-Trust by default:
+
+- never trust based on network location;
+- always verify identity, integrity, and authorization per message;
+- enforce least privilege for every route and branch;
+- assume breach and contain by scope, policy, and rapid revocation;
+- log every security-relevant decision for audit and replay analysis.
+
+## 2. Identity Verification
+
+Every mesh participant (service, agent, gateway, tunnel endpoint) must have a verifiable cryptographic identity.
+
+Identity requirements:
+
+- unique workload identity with stable principal ID;
+- signed identity credential issued by trusted mesh CA/issuer;
+- key rotation support with versioned key IDs;
+- tenant and role binding in identity claims;
+- revocation status check before packet acceptance.
+
+## 3. Authentication Methods
+
+Supported authentication methods:
+
+- mutual TLS (mTLS) for transport-level peer authentication;
+- per-packet digital signatures (for example Ed25519/ECDSA) for message-level authenticity;
+- short-lived workload tokens (OIDC/JWT or equivalent) for control-plane actions;
+- certificate pinning and trust-chain validation at ingress.
+
+Rules:
+
+- transport authentication is mandatory but not sufficient;
+- packet signature validation is mandatory at ingress and target;
+- expired or revoked credentials cause hard reject.
+
+## 4. Authorization Rules
+
+Authorization is evaluated for each packet and each delivery branch.
+
+Core rules:
+
+- authorize by principal, packet family, action, and destination capability;
+- enforce tenant/session scope matching;
+- enforce governance tags and data-classification constraints;
+- deny by default when policy is missing or ambiguous;
+- apply least-privilege permissions with explicit allowlists;
+- branch-level authorization is required even for previously validated packets.
+
+## 5. Packet Validation Pipeline
+
+Canonical validation pipeline:
+
+1. transport auth check (mTLS/session trust)
+2. schema and required-field validation
+3. timestamp/TTL/expiry validation
+4. signature and key validation
+5. nonce/idempotency/replay-window check
+6. tenant/session scope check
+7. authorization policy evaluation
+8. governance policy gates
+9. route admission or quarantine decision
+
+Any failed stage results in reject or quarantine based on policy.
+
+## 6. Quarantine System
+
+Quarantine isolates suspicious or non-compliant packets from operational flows.
+
+Quarantine triggers:
+
+- signature mismatch or unknown key ID;
+- policy violations or unauthorized branch attempts;
+- malformed schema or inconsistent lineage;
+- replay suspicion or nonce collision;
+- anomalous sender behavior above threshold.
+
+Quarantine behavior:
+
+- move packet to isolated queue/storage;
+- emit security receipt with reason code;
+- block downstream delivery until adjudication;
+- support manual or automated release/deny workflow;
+- retain artifacts per security retention policy.
+
+## 7. Message Integrity Validation
+
+Integrity controls ensure packet content cannot be modified undetected.
+
+Requirements:
+
+- canonical serialization before hash/sign operations;
+- payload hash verification on every ingress and target hop;
+- signature verification against trusted key material;
+- immutable lineage fields (`packet_id`, `parent_packet_id`, trace IDs);
+- tamper-evident audit records for validation outcomes.
+
+Integrity failures are security events and must be logged at high severity.
+
+## 8. Replay Protection
+
+Replay defense is mandatory for all packet families.
+
+Replay controls:
+
+- globally unique packet IDs and sender-scoped nonces;
+- strict validity windows using `created_at` and `expires_at`;
+- dedup cache keyed by `(packet_id, sender_id, nonce)`;
+- monotonic sequence checks where ordered streams are required;
+- challenge-response or token binding for sensitive directives.
+
+Suspected replay packets are rejected or quarantined based on policy criticality.
+
+## 9. Auditability Requirements
+
+Zero-Trust messaging must be fully auditable end-to-end.
+
+Audit requirements:
+
+- log every authentication, authorization, and validation decision;
+- include reason codes, policy IDs, actor IDs, and timestamps;
+- preserve packet lineage and branch-level outcomes;
+- record quarantine intake, adjudication, and release/deny events;
+- retain acknowledgements/receipts linked to original packet IDs;
+- support deterministic replay for incident investigation;
+- enforce immutable, access-controlled audit storage.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    In[Inbound Packet] --> T[Transport Auth mTLS]
+    T --> S[Schema + Required Fields]
+    S --> I[Integrity Check Hash + Signature]
+    I --> R[Replay Check Nonce + Window + Dedup]
+    R --> A[Authorization + Governance]
+    A -->|allow| D[Route + Deliver]
+    A -->|deny/suspect| Q[Quarantine]
+    D --> Rcpt[knowledge.receipt]
+    Q --> SecRcpt[security receipt + audit event]
+```
+
+## Enforcement Statement
+
+No packet may be routed, replayed, or promoted inside the Cognitive Mesh without passing Zero-Trust validation and branch-level authorization.
+

--- a/docs/architecture/cognitive-mesh/CM-06-deduplication-redundancy.md
+++ b/docs/architecture/cognitive-mesh/CM-06-deduplication-redundancy.md
@@ -1,0 +1,167 @@
+# Deduplication and Redundancy Architecture
+
+**Document ID:** CM-06  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Exact Packet Deduplication
+
+Exact deduplication removes byte-equivalent or identity-equivalent duplicates before downstream processing.
+
+Primary exact keys:
+
+- `packet_id`
+- `sender.id`
+- `integrity.payload_hash`
+- `integrity.nonce`
+
+Rules:
+
+- if `packet_id` is already finalized, reject as duplicate;
+- if `payload_hash + sender.id + nonce` matches active window, mark duplicate candidate;
+- exact duplicates generate receipt with disposition `duplicate_dropped`;
+- exact dedup is mandatory on ingress and before branch fan-out.
+
+## 2. Semantic Deduplication
+
+Semantic deduplication suppresses near-duplicate packets that differ syntactically but represent the same knowledge intent and effect.
+
+Semantic fingerprint inputs:
+
+- normalized packet family and routing topic;
+- canonicalized claim/action set;
+- scoped context (tenant, session, task);
+- evidence reference signature set;
+- time-bounded confidence profile.
+
+Rules:
+
+- semantic match thresholds are family-specific;
+- only eligible families (`knowledge.signal`, selected `knowledge.bundle`) can collapse semantically;
+- governance-critical directives are excluded unless explicitly allowed.
+
+## 3. Temporal Collapse Window
+
+Temporal collapse window defines the interval where equivalent events are collapsed into a single retained packet with merged metadata.
+
+Window policy:
+
+- T0/T1 traffic: short windows (for low-latency responsiveness);
+- T2 traffic: moderate windows (for throughput stability);
+- T3 replay traffic: deterministic windows aligned to replay checkpoint boundaries.
+
+Behavior:
+
+- duplicates within window are collapsed;
+- first accepted packet becomes anchor;
+- later duplicates append receipt/evidence counters to anchor metadata;
+- after window expiration, new packets are evaluated independently.
+
+## 4. Dedup Pipeline
+
+Canonical dedup pipeline:
+
+1. ingress normalization and canonical serialization
+2. exact-key check (`packet_id`, hash, nonce)
+3. replay-window and nonce freshness check
+4. semantic fingerprint generation (if eligible)
+5. collapse decision (drop, merge, or pass-through)
+6. dedup receipt emission
+7. dedup audit event persistence
+
+Any ambiguity defaults to pass-through with high-observability tagging unless policy mandates conservative drop.
+
+## 5. Packet Collapse Strategy
+
+When collapse is selected, the system retains one anchor packet and merges duplicate signals.
+
+Collapse model:
+
+- `anchor_packet_id`: canonical representative;
+- `collapsed_count`: number of folded duplicates;
+- `collapsed_sources`: unique sender/instance contributors;
+- `confidence_aggregate`: weighted update using reputation-aware scoring;
+- `evidence_union`: deduplicated evidence references.
+
+Constraints:
+
+- never alter original immutable lineage fields;
+- preserve per-duplicate receipt linkage for auditability;
+- do not collapse across tenant boundaries or incompatible governance tags.
+
+## 6. Redundancy Models
+
+Dedup operates with redundant state paths to prevent false drops and state loss.
+
+Models:
+
+- **active-active dedup caches:** parallel nodes with convergent state replication.
+- **active-passive dedup state store:** primary in-memory path, standby for failover.
+- **ledger-backed redundancy:** durable dedup outcomes persisted for replay correctness.
+
+Guidelines:
+
+- redundancy must be idempotent and conflict-resilient;
+- failover must preserve dedup decisions for in-flight windows;
+- cache loss must degrade safely (prefer temporary pass-through over unsafe drop).
+
+## 7. Replay Recovery
+
+Replay recovery reconciles dedup state after outages, failovers, or inconsistent cache epochs.
+
+Recovery sequence:
+
+1. rebuild dedup state from replay ledger checkpoints;
+2. re-evaluate uncertain packets in bounded replay window;
+3. regenerate dedup receipts for corrected dispositions;
+4. reconcile collapse metadata and downstream delivery outcomes;
+5. close recovery incident with audit trail.
+
+Rules:
+
+- replay packets must include replay lineage markers;
+- replay cannot bypass dedup checks;
+- corrected decisions must remain trace-linked to original event IDs.
+
+## 8. Duplicate Storm Prevention
+
+Duplicate storms are high-rate repeated packet bursts that can degrade mesh latency and stability. Prevention combines rate controls, suppression, and adaptive routing.
+
+Controls:
+
+- per-sender and per-topic duplicate rate limits;
+- dynamic suppression thresholds during anomaly spikes;
+- backpressure escalation to producers exceeding limits;
+- temporary quarantine for persistently abusive duplicate emitters;
+- router downgrade of non-critical duplicate-heavy traffic;
+- alerting on storm indicators (dedup drop surge, retry surge, queue growth).
+
+Mitigation policy:
+
+- protect critical control traffic first;
+- preserve audit evidence even when duplicates are dropped;
+- auto-recover to normal thresholds after stability window.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    In[Ingress Packet] --> N[Normalize]
+    N --> E[Exact Dedup Check]
+    E -->|duplicate| D1[Drop or Collapse Candidate]
+    E -->|unique| R[Replay/Nonce Check]
+    R --> S[Semantic Fingerprint]
+    S --> C[Collapse Decision Engine]
+    C -->|pass-through| Out[Route Forward]
+    C -->|collapse| A[Anchor Merge Store]
+    A --> Out
+    D1 --> Rcpt[Dedup Receipt + Audit]
+    A --> Rcpt
+    Out --> Rcpt
+```
+
+## Enforcement Statement
+
+Deduplication must be deterministic within configured windows, replay-correct under redundancy transitions, and fully auditable for every drop, merge, and pass-through decision.
+

--- a/docs/architecture/cognitive-mesh/CM-07-mesh-router.md
+++ b/docs/architecture/cognitive-mesh/CM-07-mesh-router.md
@@ -1,0 +1,189 @@
+# Mesh Router
+
+**Document ID:** CM-07  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Router Responsibilities
+
+The Mesh Router is the routing brain of the RocketGPT Cognitive Mesh. It performs policy-aware, low-latency packet dispatch across operational, learning, and control horizons while preserving Zero-Trust and governance guarantees.
+
+Primary responsibilities:
+
+- classify incoming packets by family, intent, and criticality;
+- select destinations and tunnel classes based on policy and context;
+- enforce branch-level authorization and scope boundaries;
+- optimize path selection for latency, reliability, and load;
+- orchestrate failover, replay triggers, and delivery reconciliation;
+- emit routing telemetry and auditable decision traces.
+
+## 2. Packet Classification
+
+Before routing, packets are classified into actionable routing profiles.
+
+Classification dimensions:
+
+- packet family (`knowledge.signal`, `knowledge.bundle`, `knowledge.delta`, `knowledge.directive`, `knowledge.receipt`);
+- urgency/priority (`P0`-`P3`);
+- trust posture (sender reputation, validation strength, governance tags);
+- delivery mode (single, dual, triple, replay);
+- workload class (interactive, batch, audit/recovery);
+- scope (tenant, session, global-authorized only).
+
+Classification output:
+
+- routing profile ID;
+- eligible destination set;
+- required acknowledgement mode;
+- SLA target and timeout budget.
+
+## 3. Routing Decision Engine
+
+The Routing Decision Engine computes final dispatch plans from packet classification, live topology state, and policy constraints.
+
+Decision inputs:
+
+- classification profile;
+- destination capability registry;
+- tunnel health and queue depth;
+- reputation and confidence signals;
+- governance/policy constraints;
+- topic heatmap state.
+
+Decision outputs:
+
+- selected destination branches;
+- tunnel class and failover path;
+- retry strategy and acknowledgement contract;
+- observability tags and trace context.
+
+Decisioning rules:
+
+- policy constraints are hard gates;
+- SLA-critical traffic receives shortest safe path;
+- non-critical traffic may be delayed or downgraded under pressure;
+- uncertain or suspicious traffic can be quarantined or routed to replay workflows.
+
+## 4. Routing Policies
+
+Routing policies are declarative rules evaluated per packet and per branch.
+
+Policy categories:
+
+- **security policies:** identity, authorization, scope, trust thresholds.
+- **governance policies:** promotion limits, retention class, compliance tags.
+- **performance policies:** latency budgets, queue limits, backpressure behavior.
+- **resilience policies:** redundancy mode, failover criteria, replay eligibility.
+- **cost/efficiency policies:** fan-out bounds, heavy-payload handling, tunnel selection.
+
+Policy behavior:
+
+- deny-by-default when mandatory policy is absent;
+- explicit policy precedence and conflict resolution order;
+- policy decisions must include reason codes for auditability.
+
+## 5. Topic Heatmaps
+
+Topic heatmaps are continuously updated traffic-intelligence maps used to optimize routing under changing load and behavior.
+
+Tracked dimensions:
+
+- topic throughput and burst rate;
+- latency distribution by destination/tunnel;
+- drop, retry, and dedup rates;
+- error clusters by packet family and sender class;
+- replay volume and backlog by topic.
+
+Heatmap use cases:
+
+- proactive congestion avoidance;
+- dynamic priority shaping;
+- anomaly detection and duplicate storm mitigation;
+- preemptive failover for degrading paths.
+
+## 6. Routing Destinations
+
+The Mesh Router supports direct and branched delivery to core destination classes.
+
+Destination classes:
+
+- CATS execution endpoints;
+- librarian services (EKL/IKL/SIL interfaces);
+- learner services;
+- expert consortium endpoints;
+- reputation engine;
+- governance gates/control handlers;
+- replay/repair handlers (T3 flows).
+
+Destination selection rules:
+
+- destination must advertise required capability;
+- destination must pass branch-level authorization;
+- destination SLA compatibility must match packet profile;
+- multi-target delivery uses split-horizon routing contracts.
+
+## 7. Routing SLA
+
+Routing SLA defines acceptable timing and reliability for dispatch decisions and handoff.
+
+SLA targets:
+
+- route decision latency: <= 5 ms p95 for interactive classes;
+- dispatch handoff latency: <= 10 ms p95 (decision-to-tunnel enqueue);
+- high-priority delivery conformance aligned to tunnel SLA (`P0`/`P1`);
+- bounded failover detection and reroute under degradation.
+
+SLA controls:
+
+- queue admission limits by priority;
+- adaptive backpressure and shedding for non-critical traffic;
+- fail-open/fail-safe behavior explicitly policy-defined per topic.
+
+## 8. Routing Telemetry
+
+Routing telemetry provides real-time health, optimization inputs, and audit evidence.
+
+Required telemetry:
+
+- `route_decision_latency_ms` (p50/p95/p99)
+- `route_handoff_latency_ms`
+- `route_success_rate`
+- `route_failover_rate`
+- `route_policy_deny_rate`
+- `route_branch_fanout_count`
+- `route_queue_depth`
+- `route_retry_rate`
+- `route_quarantine_rate`
+- `route_replay_trigger_rate`
+
+Telemetry requirements:
+
+- dimensions: tenant, topic, packet family, tunnel class, destination class;
+- correlation with packet lineage and trace IDs;
+- retention aligned with governance and incident forensics.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    In[Validated KPP Packet] --> C[Packet Classification]
+    C --> D[Routing Decision Engine]
+    P[Routing Policies] --> D
+    H[Topic Heatmaps] --> D
+    T[Topology + Tunnel Health] --> D
+    D --> B[Branch Planner]
+    B --> CATS[CATS Destinations]
+    B --> LIB[Librarian Destinations]
+    B --> LEARN[Learner Destinations]
+    B --> EXP[Expert Consortium]
+    B --> REP[Reputation Engine]
+    B --> GOV[Governance/Control]
+    B --> RPL[Replay/Repair]
+    B --> TM[Routing Telemetry + Audit]
+```
+
+## Enforcement Statement
+
+The Mesh Router must make deterministic, policy-compliant routing decisions under Zero-Trust constraints and produce complete telemetry and audit lineage for every dispatch outcome.
+

--- a/docs/architecture/cognitive-mesh/CM-08-knowledge-libraries-and-promotion.md
+++ b/docs/architecture/cognitive-mesh/CM-08-knowledge-libraries-and-promotion.md
@@ -1,0 +1,177 @@
+# Knowledge Libraries and Promotion
+
+**Document ID:** CM-08  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. SIL (Signal Intelligence Layer)
+
+SIL is the session-scoped, high-velocity intelligence layer that stores transient signals, hypotheses, and improvisations generated during active execution.
+
+Purpose:
+
+- capture short-lived contextual intelligence quickly;
+- support rapid adaptation inside a session boundary;
+- isolate unproven knowledge from durable libraries.
+
+Characteristics:
+
+- ephemeral retention by default;
+- high write rate, low promotion confidence baseline;
+- strict tenant/session isolation;
+- no global reuse unless explicitly promoted.
+
+## 2. IKL (Intermediate Knowledge Library)
+
+IKL is the governed staging library for knowledge that has passed initial quality checks but is not yet elevated to explicit enterprise-grade truth.
+
+Purpose:
+
+- hold candidate reusable knowledge with evidence trails;
+- support controlled experimentation and validation;
+- separate validated-but-not-final intelligence from ephemeral SIL signals.
+
+Characteristics:
+
+- medium retention window;
+- evidence-indexed and versioned entries;
+- scoped reuse across approved tenants/domains;
+- subject to ongoing quality and drift checks.
+
+## 3. EKL (Explicit Knowledge Library)
+
+EKL is the durable, high-confidence knowledge library containing explicitly approved, policy-compliant knowledge artifacts for broad operational reuse.
+
+Purpose:
+
+- provide trusted, production-grade knowledge for critical paths;
+- ensure stable retrieval with audit-ready provenance;
+- serve as authoritative source for explicit standards and accepted patterns.
+
+Characteristics:
+
+- long retention and strict governance controls;
+- highest entry threshold and strongest evidence requirements;
+- formal versioning and compatibility constraints;
+- full audit and revocation traceability.
+
+## 4. Knowledge Lifecycle
+
+Canonical lifecycle:
+
+1. **Ingest to SIL:** packet-derived signal/hypothesis enters session scope.
+2. **Stabilize:** dedup, aggregate evidence, and score utility/confidence.
+3. **Promote candidate to IKL:** governance-gated transition for reusable intermediate knowledge.
+4. **Validate in IKL:** monitor outcomes, drift, and cross-context performance.
+5. **Promote to EKL:** explicit approval for durable broad reuse.
+6. **Operate and monitor:** continuous telemetry, quality scoring, and policy checks.
+7. **Demote or revoke:** if degradation, policy conflict, or integrity issues occur.
+
+## 5. Promotion Rules
+
+Promotion is policy-gated and evidence-driven.
+
+SIL -> IKL rules:
+
+- minimum evidence threshold met;
+- positive utility/reliability trend within session or scoped cohort;
+- no unresolved governance or security flags;
+- explicit promotion action from authorized actor/workflow.
+
+IKL -> EKL rules:
+
+- sustained performance above quality threshold;
+- cross-context consistency demonstrated;
+- full provenance and reproducibility metadata present;
+- governance approval with auditable decision record.
+
+General constraints:
+
+- promotions must preserve lineage links to source packets;
+- promotion never bypasses Zero-Trust and governance checks.
+
+## 6. Demotion Rules
+
+Demotion moves knowledge to a lower-trust layer when confidence declines but immediate hard revocation is not required.
+
+Demotion triggers:
+
+- performance regression beyond policy threshold;
+- drift signals reducing reliability in target contexts;
+- conflicting higher-quality evidence;
+- partial compliance concerns under investigation.
+
+Demotion paths:
+
+- EKL -> IKL for revalidation;
+- IKL -> SIL or archival quarantine for limited/session-only use.
+
+Demotion requirements:
+
+- retain full history and reason codes;
+- notify dependent routing and retrieval systems.
+
+## 7. Revocation Rules
+
+Revocation is a hard invalidation action for unsafe, non-compliant, or corrupted knowledge artifacts.
+
+Revocation triggers:
+
+- security integrity failure or tamper evidence;
+- policy/legal non-compliance;
+- critical factual invalidation with operational risk;
+- unauthorized promotion lineage.
+
+Revocation behavior:
+
+- immediate retrieval block on revoked version;
+- propagation of revocation directive to router, libraries, and caches;
+- mandatory incident/audit record creation;
+- optional rollback to last known-good version when available.
+
+## 8. Governance Interaction
+
+Governance is authoritative for lifecycle transitions and enforcement.
+
+Governance responsibilities:
+
+- define thresholds for promotion, demotion, and revocation;
+- enforce tenant/data-classification and retention policies;
+- approve or deny lifecycle transitions with reason codes;
+- require evidence completeness before durable elevation;
+- trigger review workflows for anomalies and disputes.
+
+Integration model:
+
+- lifecycle events are emitted as governed packets/directives;
+- governance hooks execute before state transitions;
+- all decisions are audit-linked to lineage and evidence.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    SIL[SIL: Signal Intelligence Layer] -->|promote candidate| G1[Governance Gate]
+    G1 -->|approved| IKL[IKL: Intermediate Knowledge]
+    G1 -->|denied| SIL
+    IKL -->|promote candidate| G2[Governance Gate]
+    G2 -->|approved| EKL[EKL: Explicit Knowledge]
+    G2 -->|denied| IKL
+    EKL -->|demotion| IKL
+    IKL -->|demotion| SIL
+    EKL -->|revocation| RV[Revoked/Blocked]
+    IKL -->|revocation| RV
+    SIL -->|expiry| AR[Archive/Expire]
+```
+
+## Related Specifications
+
+- [CM-12 Suggestion Outcome Registry](./CM-12-suggestion-outcome-registry.md)
+- [CM-14 Consolidated Governance Rules](./CM-14-consolidated-governance-rules.md)
+- [CM-18 Learner Reputation Ledger](./CM-18-learner-reputation-ledger.md)
+
+## Enforcement Statement
+
+No knowledge artifact may transition across SIL, IKL, and EKL without governed policy evaluation, evidence-linked lineage, and auditable decision records.
+

--- a/docs/architecture/cognitive-mesh/CM-09-expert-consortium.md
+++ b/docs/architecture/cognitive-mesh/CM-09-expert-consortium.md
@@ -1,0 +1,171 @@
+# Expert Consortium
+
+**Document ID:** CM-09  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose of Consortium
+
+The Expert Consortium is the structured multi-expert review system inside the Cognitive Mesh. It provides high-confidence adjudication for complex, ambiguous, or high-impact knowledge decisions before promotion, enforcement, or broad operational use.
+
+Primary objectives:
+
+- reduce single-expert bias and failure modes;
+- improve decision quality through adversarial and cooperative review;
+- provide evidence-linked consensus or dissent records;
+- support governed escalation for unresolved or risky outcomes.
+
+## 2. Expert Roles
+
+The consortium is role-based, with each expert operating under explicit scope and authority limits.
+
+Core roles:
+
+- **Domain Expert:** evaluates technical or domain correctness.
+- **Risk Expert:** evaluates operational, security, and compliance risk.
+- **Evidence Auditor:** validates provenance quality, reproducibility, and confidence claims.
+- **Systems Expert:** evaluates runtime impact, latency, and integration constraints.
+- **Governance Liaison:** checks policy compatibility and gate readiness.
+
+Role constraints:
+
+- each role has bounded decision authority;
+- role identity must be cryptographically verifiable;
+- conflict-of-interest policies must be enforced where applicable.
+
+## 3. Debate Protocol
+
+The consortium uses a staged debate protocol for structured review.
+
+Protocol stages:
+
+1. **Intake:** topic review packet is accepted and scoped.
+2. **Positioning:** experts submit initial positions with evidence.
+3. **Challenge Round:** experts critique assumptions, evidence, and tradeoffs.
+4. **Revision Round:** experts update positions after challenges.
+5. **Synthesis:** chair or synthesis engine compiles agreement/disagreement map.
+6. **Decision:** voting produces decision packet with rationale and confidence.
+
+Protocol rules:
+
+- all claims must reference evidence IDs;
+- unsupported assertions are marked low weight;
+- debate windows are time-bounded by SLA class.
+
+## 4. Topic Review Packets
+
+Topic review packets initiate consortium analysis and define review boundaries.
+
+Required fields:
+
+- `topic_id`
+- `review_scope` (question, constraints, allowed action space)
+- `risk_class`
+- `required_roles`
+- `evidence_bundle_refs`
+- `deadline_at`
+- `governance_tags`
+
+Typical family mapping:
+
+- `knowledge.bundle` for primary topic context;
+- `knowledge.signal` for supplemental observations;
+- `knowledge.directive` for mandatory review triggers.
+
+## 5. Decision Packets
+
+Decision packets are formal outputs of consortium adjudication.
+
+Decision packet contents:
+
+- final disposition (`approve`, `approve_with_conditions`, `reject`, `defer`);
+- vote summary and quorum status;
+- weighted rationale and key evidence links;
+- dissent notes and minority reports;
+- recommended next action (promote, hold, replay, escalate);
+- governance and SLA metadata.
+
+Decision packets are immutable, signed artifacts and must be auditable end-to-end.
+
+## 6. Voting System
+
+Voting is weighted, role-aware, and evidence-adjusted.
+
+Voting mechanics:
+
+- each eligible role receives a base voting weight;
+- weight can be adjusted by reputation and evidence quality score;
+- quorum threshold depends on risk class;
+- supermajority may be required for high-risk promotions/directives.
+
+Vote outcomes:
+
+- **consensus:** threshold met with low dissent severity;
+- **qualified approval:** threshold met with conditions;
+- **rejection:** threshold not met or risk veto triggered;
+- **deadlock:** insufficient convergence before deadline.
+
+## 7. Escalation
+
+Escalation is required when consortium outcomes are blocked, conflicting, or high risk.
+
+Escalation triggers:
+
+- vote deadlock at or beyond deadline;
+- risk veto on otherwise approving vote;
+- governance conflict with proposed decision;
+- repeated disagreement across replayed reviews.
+
+Escalation paths:
+
+- expanded panel with additional experts;
+- governance board adjudication;
+- emergency control directive for critical incidents;
+- defer-and-observe with explicit risk acceptance.
+
+All escalations must emit trace-linked directives and resolution receipts.
+
+## 8. Creativity Guardrails
+
+The consortium supports creative alternatives but enforces safety and quality guardrails.
+
+Guardrail rules:
+
+- creativity must remain within declared policy and risk boundaries;
+- novel proposals require stronger evidence and staged rollout conditions;
+- hallucinated or unverifiable claims are disallowed from decision weighting;
+- high-variance ideas default to sandbox or limited-scope deployment;
+- guardrails cannot be bypassed through majority vote alone.
+
+Creativity is encouraged for option generation, not for bypassing governance or integrity constraints.
+
+## 9. Learner Rating Boundary
+
+Consortium decisions may influence knowledge promotion or execution paths but must never directly modify Learner Ratings. Learner Ratings are computed only by the Independent Rating Engine using external evidence events.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    TRP[Topic Review Packet] --> IN[Intake + Scope Validation]
+    IN --> DB[Debate Protocol]
+    DB --> V[Voting Engine]
+    V --> DP[Decision Packet]
+    DP --> G[Governance Gates]
+    G -->|approved| ACT[Promotion/Execution Action]
+    G -->|escalate| ESC[Escalation Path]
+    DB --> EVD[Evidence Auditor]
+    EVD --> V
+```
+
+## Related Specifications
+
+- [CM-16 Topic Review Registry](./CM-16-topic-review-registry.md)
+- [CM-17 Consortium Decision Registry](./CM-17-consortium-decision-registry.md)
+- [CM-14 Consolidated Governance Rules](./CM-14-consolidated-governance-rules.md)
+
+## Enforcement Statement
+
+No consortium decision may alter durable knowledge or runtime control behavior unless emitted as a signed decision packet and accepted through governance-authorized pathways.
+

--- a/docs/architecture/cognitive-mesh/CM-10-dynamic-consortium-membership.md
+++ b/docs/architecture/cognitive-mesh/CM-10-dynamic-consortium-membership.md
@@ -1,0 +1,126 @@
+# Dynamic Consortium Membership
+
+**Document ID:** CM-10  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Dynamic Council Concept
+
+The Expert Consortium uses a dynamic council model in which membership is continuously re-evaluated from observed merit, relevance, and governance compliance rather than fixed static appointments.
+
+Goals:
+
+- maximize decision quality for current topic domains;
+- adapt membership to changing performance signals;
+- reduce long-term concentration of influence;
+- maintain resilience through rotating expertise coverage.
+
+The council is assembled per review scope and risk class using policy-bound selection logic.
+
+## 2. Learners as Candidates
+
+Learners are eligible to serve as candidate consortium members when their outputs demonstrate sustained quality, evidence discipline, and policy compliance.
+
+Candidate pathway:
+
+1. learner emits high-quality, evidence-linked recommendations in production-adjacent flows;
+2. reputation engine confirms minimum performance and reliability thresholds;
+3. governance verifies behavioral and security compliance;
+4. learner is enrolled into candidate pool with scoped role permissions.
+
+Constraints:
+
+- learner candidacy is topic/domain-scoped;
+- candidates cannot self-approve their own promotion artifacts;
+- candidate status is revocable on quality, integrity, or policy regressions.
+
+## 3. Membership Rotation Rules
+
+Membership rotates on schedule and event triggers to preserve freshness and reduce systemic bias.
+
+Rotation rules:
+
+- fixed maximum consecutive terms per member per role;
+- cooldown interval before re-selection to the same panel class;
+- mandatory partial turnover per cycle (for example minimum one-third change);
+- immediate rotation triggers on risk, conflict, or sustained underperformance events;
+- emergency continuity path allowed for critical incidents with explicit governance approval.
+
+## 4. Eligibility Criteria
+
+Eligibility is determined by measurable merit and compliance indicators.
+
+Required criteria:
+
+- minimum externally validated Learner Reputation score in relevant domain;
+- evidence completeness and reproducibility quality above threshold;
+- recent decision accuracy and calibration quality;
+- low policy violation and security incident rates;
+- active identity validity and authorization scope.
+
+Additional eligibility law:
+
+- consortium membership eligibility requires externally validated Learner Reputation scores produced by the Independent Rating Engine;
+- internal endorsements or debate participation cannot influence eligibility.
+
+Disqualifiers:
+
+- unresolved integrity or tamper findings;
+- repeated governance non-compliance;
+- conflict-of-interest flags not mitigated by policy.
+
+## 5. Bias Prevention Rules
+
+The council selection process must actively prevent concentration and systemic bias.
+
+Bias controls:
+
+- diversity constraints across role type, model lineage, and evidence style;
+- anti-dominance caps on repeated member selection;
+- weighted randomization within qualified candidate bands;
+- blind-first evidence scoring before identity reveal where feasible;
+- drift and bias audits on voting outcomes over time;
+- automatic escalation when bias indicators exceed thresholds.
+
+Bias prevention is enforced as a first-class policy, not an optional preference.
+
+## 6. Chair Limitations
+
+The consortium chair coordinates process flow but does not hold unrestricted authority.
+
+Chair limitations:
+
+- cannot unilaterally override quorum/voting requirements;
+- cannot suppress registered dissent records;
+- cannot bypass governance gates or Zero-Trust controls;
+- must disclose conflicts and recuse when required;
+- subject to term limits and rotation rules;
+- all chair interventions must be audit-logged with reason codes.
+
+The chair is a procedural coordinator, not a final unilateral decision authority.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    CP[Candidate Pool] --> SEL[Membership Selector]
+    REP[Reputation Engine] --> SEL
+    GOV[Governance Policies] --> SEL
+    BIAS[Bias Guardrails] --> SEL
+    SEL --> COUNCIL[Dynamic Council]
+    COUNCIL --> CHAIR[Chair (Limited Authority)]
+    CHAIR --> VOTE[Debate + Voting]
+    VOTE --> AUDIT[Audit + Rotation Signals]
+    AUDIT --> SEL
+```
+
+## Related Specifications
+
+- [CM-11 Learner Reputation Engine](./CM-11-learner-reputation-engine.md)
+- [CM-13 Rating Evidence Events](./CM-13-rating-evidence-events.md)
+
+## Enforcement Statement
+
+Consortium membership must remain merit-based, policy-governed, bias-controlled, and auditable, with no permanent authority concentration in members or chair roles.
+

--- a/docs/architecture/cognitive-mesh/CM-11-learner-reputation-engine.md
+++ b/docs/architecture/cognitive-mesh/CM-11-learner-reputation-engine.md
@@ -1,0 +1,217 @@
+# Learner Reputation Engine
+
+**Document ID:** CM-11  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose
+
+The Learner Reputation Engine (Independent Rating Engine) evaluates the reliability, utility, and governance compliance of learner outputs in the Cognitive Mesh. It produces evidence-linked Learner Ratings and aggregated Learner Reputation profiles that control routing priority, promotion eligibility, and consortium candidacy.
+
+## 2. Scope
+
+The engine applies to:
+
+- learner-generated `knowledge.signal`, `knowledge.bundle`, and `knowledge.delta` packets;
+- learner participation in consortium review workflows;
+- post-deployment outcome feedback tied to learner proposals.
+
+It does not replace governance gates; it provides trust signals to them.
+
+## 3. Core Responsibilities
+
+- compute per-learner and per-domain Learner Ratings;
+- update ratings continuously from validated external outcomes;
+- expose explainable score factors and confidence intervals;
+- emit rating and reputation events for router, librarian, and governance consumers;
+- enforce session isolation for improvise intelligence unless promoted.
+
+## 4. Reputation Scoring System
+
+### 4.1 Reputation Dimensions
+
+Reputation is computed across six dimensions:
+
+- outcome quality (task success, regression rate, rollback impact);
+- evidence quality (completeness, provenance, reproducibility);
+- calibration quality (confidence-to-correctness alignment);
+- governance compliance (policy pass/fail and severity);
+- operational efficiency (latency, timeout, fallback pressure);
+- collaboration quality (consortium alignment and dissent quality).
+
+### 4.2 Scoring Algorithm
+
+The score uses a weighted factor model with bounded output.
+
+Algorithm outline:
+
+1. normalize each dimension to `[0,1]`;
+2. apply versioned dimension weights per domain/risk class;
+3. compute weighted sum and penalty terms;
+4. apply confidence adjustment for sparse evidence;
+5. map to final `0-100` Learner Rating.
+
+Constraints:
+
+- governance or integrity critical failures apply hard penalties;
+- correlated low-diversity evidence is down-weighted;
+- model version changes must be audit-versioned.
+
+### 4.3 Reputation Decay
+
+Reputation decays over time to prevent stale performance from dominating current trust.
+
+Decay rules:
+
+- inactivity decay applies continuously after configurable idle threshold;
+- recent verified outcomes have higher influence than historical outcomes;
+- decay rate is stricter for high-risk domains;
+- positive recovery is possible through new high-quality evidence.
+
+### 4.4 Scoring Time Windows
+
+Scoring combines multiple windows to balance recency and stability.
+
+Windows:
+
+- short window: rapid behavior change detection;
+- medium window: operational stability assessment;
+- long window: durable reliability baseline.
+
+Windowed scoring:
+
+- short-window anomalies can trigger provisional tier changes;
+- medium/long windows stabilize against transient noise;
+- final score blends all windows using policy-defined weights.
+
+### 4.5 Score Explainability
+
+Every score update must produce machine- and human-readable explanations.
+
+Explainability outputs:
+
+- top positive and negative contributing dimensions;
+- recent events with largest score impact;
+- penalties applied and corresponding policy IDs;
+- confidence band and data sufficiency indicator;
+- model version and weight profile used.
+
+### 4.6 Reputation Auditability
+
+All scoring decisions must be replayable and trace-linked.
+
+Audit requirements:
+
+- immutable score snapshots with timestamp and lineage keys;
+- full event trail for each score delta;
+- versioned weights, thresholds, and decay parameters;
+- reason-coded tier changes (`trusted`, `provisional`, `restricted`, `blocked`);
+- deterministic recomputation support for investigations.
+
+## 5. Inputs and Signals
+
+Primary rating evidence classes (direct Learner Rating inputs only):
+
+- chat outcomes;
+- CATS execution outcomes;
+- governance decisions (approve/deny/revoke);
+- external validated runtime or business telemetry systems.
+
+Derived Signals (advisory only, not direct Learner Rating inputs):
+
+- routing performance metrics;
+- incident and quarantine events;
+- tunnel-level delivery behavior;
+- consortium debate dynamics.
+
+All inputs must include lineage keys (`packet_id`, `trace_id`, `learner_id`).
+
+## 6. Score Outputs
+
+The engine produces:
+
+- `learner_rating` (0-100 external outcome-driven score);
+- `learner_reputation_profile` (aggregated historical Learner Rating profile);
+- `reputation_tier` (`trusted`, `provisional`, `restricted`, `blocked`);
+- `confidence_band` (statistical confidence of score);
+- `risk_flags` (policy or behavior warnings);
+- `explainability_vector` (top contributing factors).
+
+## 7. Decision Integrations
+
+### Routing Integration
+
+- high-tier learners receive preferred routing for eligible topics;
+- restricted learners may be rate-limited, sandboxed, or deprioritized.
+
+### Promotion Integration
+
+- SIL -> IKL and IKL -> EKL promotions consume reputation as an input signal;
+- low reputation cannot be used to bypass governance denial.
+
+### Consortium Integration
+
+- learner candidacy and voting weight are reputation-gated;
+- risk flags can trigger temporary disqualification.
+
+## 8. Reputation Update Lifecycle
+
+1. ingest lineage-linked outcome events  
+2. validate integrity and scope  
+3. compute factor deltas  
+4. apply weighted score update with temporal decay  
+5. assign tier and risk flags  
+6. publish reputation event packet  
+7. persist auditable score snapshot
+
+## Related Specifications
+
+- [CM-13 Rating Evidence Events](./CM-13-rating-evidence-events.md)
+- [CM-18 Learner Reputation Ledger](./CM-18-learner-reputation-ledger.md)
+- [CM-12 Suggestion Outcome Registry](./CM-12-suggestion-outcome-registry.md)
+
+## 9. Safety and Anti-Gaming Controls
+
+- anomaly detection for suspicious self-reinforcing feedback loops;
+- cap score lift from correlated or low-diversity evidence sources;
+- penalize unverifiable claims and repeated rollback-causing deltas;
+- separate training/evaluation paths to reduce leakage bias;
+- require governance review on rapid score spikes.
+
+## 10. Auditability Requirements
+
+- every score change must be traceable to source events;
+- snapshots must be immutable and replayable;
+- factor weights and policy thresholds must be versioned;
+- demotion/block actions require explicit reason codes.
+
+## 11. Key Metrics
+
+- `learner_reputation_score`
+- `reputation_update_latency_ms`
+- `reputation_confidence`
+- `reputation_demotion_rate`
+- `reputation_block_rate`
+- `reputation_recovery_rate`
+- `reputation_disagreement_rate` (score vs governance outcomes)
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    E[Outcome + Governance + Routing Events] --> V[Signal Validation]
+    V --> F[Factor Extractor]
+    F --> M[Scoring Model + Decay]
+    M --> T[Tiering + Risk Flags]
+    T --> O[Reputation Event Output]
+    O --> R[Mesh Router]
+    O --> G[Governance Gates]
+    O --> C[Consortium Selector]
+    M --> A[Audit Snapshot Store]
+```
+
+## Enforcement Statement
+
+Learner reputation decisions must be evidence-driven, non-bypassable by a single subsystem, and fully auditable across routing, promotion, and governance interactions.
+

--- a/docs/architecture/cognitive-mesh/CM-12-suggestion-outcome-registry.md
+++ b/docs/architecture/cognitive-mesh/CM-12-suggestion-outcome-registry.md
@@ -1,0 +1,113 @@
+# Suggestion Outcome Registry
+
+**Document ID:** CM-12  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Suggestion Lifecycle
+
+The Suggestion Outcome Registry tracks learner suggestions from creation to terminal disposition.
+
+Lifecycle states:
+
+1. `proposed`: learner emits suggestion packet with evidence.
+2. `validated`: schema, integrity, and policy prechecks pass.
+3. `accepted_for_trial`: suggestion approved for bounded execution scope.
+4. `executed`: CATS applies suggestion in one or more runs.
+5. `evaluated`: outcomes measured against baselines and constraints.
+6. `closed`: finalized as `adopted`, `rejected`, `rolled_back`, or `expired`.
+
+Each transition must be timestamped and linked to packet lineage.
+
+## 2. Linking Suggestions to CATS
+
+Every suggestion must be explicitly tied to CATS execution context.
+
+Required links:
+
+- `suggestion_id` -> `cats_plan_id`
+- `suggestion_id` -> `cats_run_id` (one-to-many supported)
+- `suggestion_id` -> `task_type` and environment scope
+- `suggestion_id` -> governing policy decision ID
+
+Linking rules:
+
+- no suggestion may affect CATS without a resolvable `suggestion_id`;
+- CATS must emit execution receipts referencing originating suggestion;
+- replayed runs retain original suggestion lineage plus replay markers.
+
+## 3. Outcome Metrics
+
+Outcome measurement is mandatory for all executed suggestions.
+
+Core metrics:
+
+- success delta vs baseline (`quality_delta`);
+- latency impact (`plan_latency_ms`, `first_response_ms`);
+- reliability impact (`timeout_rate`, `fallback_rate`);
+- behavioral adoption impact (`improvise_rate`, `deep_mode_rate`);
+- governance impact (policy pass/fail, exceptions raised).
+
+Measurement rules:
+
+- metrics must be windowed and baseline-aware;
+- negative safety or compliance outcomes override positive performance gains;
+- confidence score must accompany low-sample evaluations.
+
+## 4. Reuse Tracking
+
+Registry tracks where and how suggestions are reused across tasks and contexts.
+
+Reuse dimensions:
+
+- reuse count by task/domain;
+- tenant/session reuse boundaries;
+- successful vs failed reuse ratio;
+- time-to-reuse after initial adoption;
+- dependency graph of derived suggestions.
+
+Controls:
+
+- SIL-scope suggestions are session-isolated unless promoted;
+- IKL/EKL promoted suggestions gain broader reuse eligibility;
+- reuse in new contexts requires policy-compatible scope checks.
+
+## 5. Accountability Model
+
+The registry enforces clear accountability for each suggestion decision and impact.
+
+Accountability entities:
+
+- proposer (learner/expert/service principal);
+- approver (governance/consortium actor);
+- executor (CATS runtime context);
+- evaluator (metrics/review subsystem).
+
+Accountability requirements:
+
+- all actors must be identity-verifiable;
+- every decision must have reason codes and evidence references;
+- adverse outcomes must map to responsible decision points;
+- rollback and revocation actions must link to originating suggestion IDs;
+- immutable audit records must support deterministic incident reconstruction.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    S[Suggestion Packet] --> V[Validate + Policy Check]
+    V --> T[Trial Approval]
+    T --> C[CATS Execution]
+    C --> M[Outcome Metrics]
+    M --> R[Suggestion Outcome Registry]
+    R --> U[Reuse Tracker]
+    R --> A[Accountability Ledger]
+    A --> G[Governance/Consortium Review]
+    G --> R
+```
+
+## Enforcement Statement
+
+No learner suggestion may be promoted, reused, or trusted without lineage-linked outcome evidence and accountable decision records in the Suggestion Outcome Registry.
+

--- a/docs/architecture/cognitive-mesh/CM-13-rating-evidence-events.md
+++ b/docs/architecture/cognitive-mesh/CM-13-rating-evidence-events.md
@@ -1,0 +1,167 @@
+# Rating Evidence Events (REE)
+
+**Document ID:** CM-13  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. REE Schema
+
+Rating Evidence Events (REE) are canonical evidence records used by the Learner Reputation Engine to justify score updates.
+
+Required schema fields:
+
+- `ree_version`
+- `event_id`
+- `event_type`
+- `occurred_at`
+- `tenant_id`
+- `session_id`
+- `learner_id`
+- `suggestion_id` (if applicable)
+- `packet_id`
+- `trace_id`
+- `source`
+- `evidence_payload`
+- `integrity.payload_hash`
+- `integrity.signature`
+- `governance.policy_tags`
+
+Recommended fields:
+
+- `confidence`
+- `severity`
+- `baseline_ref`
+- `reason_code`
+- `artifact_refs`
+- `correlation_id`
+
+## 2. Trusted Evidence Sources
+
+REE accepts evidence only from approved, identity-verified source classes.
+
+Primary evidence classes (direct Learner Rating inputs):
+
+- chat outcomes;
+- CATS execution outcomes;
+- governance decision services;
+- external validated runtime or business telemetry systems.
+
+Derived Signals (advisory only, not direct Learner Rating inputs):
+
+- messenger tunnel receipts and delivery telemetry;
+- replay/repair reconciliation services;
+- consortium decision packet emitters;
+- routing and quarantine event streams.
+
+Source requirements:
+
+- cryptographic identity and active authorization;
+- registered source capability and domain scope;
+- non-repudiable signing key under approved trust chain.
+
+## 3. Evidence Verification
+
+Verification is mandatory before REE contributes to Learner Ratings.
+
+Verification pipeline:
+
+1. schema and required-field validation
+2. source identity and certificate/token validation
+3. signature and payload-hash verification
+4. lineage validation (`packet_id`, `trace_id`, `learner_id`)
+5. policy and scope validation (tenant/session/classification)
+6. freshness and replay-window checks
+7. confidence and completeness checks
+8. acceptance, quarantine, or rejection decision
+
+Rules:
+
+- unverifiable evidence cannot affect Learner Ratings;
+- Derived Signals may enrich analysis context but cannot directly change Learner Ratings;
+- partially valid evidence may be stored but marked non-scoring;
+- rejected evidence must include auditable reason codes.
+
+## 4. Example Events
+
+### Example A: Positive Execution Outcome
+
+- `event_type`: `cats.execution.outcome`
+- signal: suggestion reduced `plan_latency_ms` and improved success rate
+- expected effect: positive score delta in outcome quality dimension
+
+### Example B: Governance Denial
+
+- `event_type`: `governance.decision.denied`
+- signal: promotion denied due to policy mismatch
+- expected effect: negative compliance-weighted score impact
+
+### Example C: Replay Repair Failure
+
+- `event_type`: `replay.repair.failed`
+- signal: reprocessed suggestion still violates quality threshold
+- expected effect: advisory reliability context; not a direct Learner Rating input
+
+### Example D: Consortium Qualified Approval
+
+- `event_type`: `consortium.decision.conditional_approve`
+- signal: accepted with constraints and evidence caveats
+- expected effect: advisory context for governance and promotion; not a direct Learner Rating input
+
+## 5. Event Lifecycle
+
+REE lifecycle:
+
+1. **Emit:** trusted source publishes REE.
+2. **Ingest:** registry accepts event to validation queue.
+3. **Verify:** integrity, identity, scope, and lineage checks run.
+4. **Classify:** scoring-eligible vs non-scoring evidence.
+5. **Apply:** eligible REE updates Learner Rating factors/windows.
+6. **Persist:** immutable event record stored with verification result.
+7. **Audit/Replay:** event is available for forensic replay and recomputation.
+8. **Expire/Archive:** retention policy governs lifecycle end state.
+
+## Sample REE JSON
+
+```json
+{
+  "ree_version": "1.0.0",
+  "event_id": "ree_01JZ9W4M9Y2KQ7DT8R4N1M3H6P",
+  "event_type": "cats.execution.outcome",
+  "occurred_at": "2026-03-06T11:04:33.455Z",
+  "tenant_id": "tenant_acme",
+  "session_id": "sess_6f9f2f03c85d",
+  "learner_id": "learner.plan.optimizer.v3",
+  "suggestion_id": "sugg_74c0b2",
+  "packet_id": "kp_01JZ9W4HF6D0A6RZJ2Q1QY4E9W",
+  "trace_id": "trc_4fa9f58df5d24718ad67",
+  "source": {
+    "id": "cats.exec.telemetry",
+    "type": "runtime_service",
+    "instance_id": "cats-exec-21"
+  },
+  "evidence_payload": {
+    "quality_delta": 0.11,
+    "plan_latency_ms_before": 412,
+    "plan_latency_ms_after": 336,
+    "timeout_rate_before": 0.021,
+    "timeout_rate_after": 0.016,
+    "baseline_ref": "ikl://benchmarks/plan/run-4202"
+  },
+  "confidence": 0.84,
+  "governance": {
+    "policy_tags": ["tenant-scoped", "evidence-required"]
+  },
+  "integrity": {
+    "alg": "ed25519",
+    "payload_hash": "sha256:8ef47e3f948f9f0357f9692d078f2cb2a94a4f839df43de5f250b157f0a6b913",
+    "signature": "base64:X2Fj...snip...",
+    "key_id": "kid_cats_exec_2026q1"
+  }
+}
+```
+
+## Enforcement Statement
+
+Only verified, lineage-complete, policy-compliant REE records may influence Learner Ratings, and every scoring decision must be traceable to accepted evidence events.
+

--- a/docs/architecture/cognitive-mesh/CM-14-consolidated-governance-rules.md
+++ b/docs/architecture/cognitive-mesh/CM-14-consolidated-governance-rules.md
@@ -1,0 +1,112 @@
+# Consolidated Governance Rules
+
+**Document ID:** CM-14  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## Purpose
+
+This document defines the non-bypassable architectural laws governing the RocketGPT Cognitive Mesh. These laws are mandatory for all mesh subsystems, including CATS execution, learners, consortium workflows, routing, and knowledge libraries.
+
+## Architectural Laws
+
+### 1. Consortium Cannot Introduce Topics
+
+The Expert Consortium may review, adjudicate, and escalate submitted topics, but it cannot originate new governance or learning topics on its own authority.
+
+Enforcement:
+
+- topic creation must originate from authorized upstream producers;
+- consortium-originated topic creation attempts must be rejected and audited.
+
+### 2. Learners Cannot Modify Ratings
+
+Learners are subjects of reputation scoring and may not write, override, or directly mutate their own rating records.
+
+Enforcement:
+
+- rating write permissions are restricted to the Reputation Engine;
+- learner-issued rating mutations must be denied and logged.
+
+### 3. Consortium Cannot Modify Ratings
+
+The consortium can provide advisory signals but cannot directly change Learner Ratings.
+
+Enforcement:
+
+- consortium outputs are Derived Signals only and cannot directly change Learner Ratings;
+- final rating updates remain exclusive to the Independent Rating Engine model pipeline.
+
+### 4. Ratings Must Come From External Evidence
+
+Learner ratings must originate only from the following validated evidence sources:
+
+- Chats
+- CATS execution engine
+- Governance engine
+- External validated runtime or business telemetry systems
+
+No learner, consortium member, or internal messaging component may directly mutate ratings.
+
+Enforcement:
+
+- only the four validated primary evidence classes may produce scoring-eligible Learner Rating events;
+- internal routing, quarantine, messenger, and consortium debate signals are Derived Signals only;
+- unverifiable or self-referential evidence cannot affect Learner Ratings.
+
+### 5. Zero-Trust Messaging Required
+
+All packet transport and processing in the mesh must follow Zero-Trust controls.
+
+Enforcement:
+
+- per-hop identity, integrity, and authorization checks are mandatory;
+- no implicit trust is allowed from network position or internal origin.
+
+### 6. Knowledge Promotion Must Be Governed
+
+Any transition across SIL, IKL, and EKL must pass governance gates with explicit policy decisions.
+
+Enforcement:
+
+- promotion without governance approval is invalid;
+- every promotion decision requires evidence linkage and audit record.
+
+### 7. Learners Accountable for CATS Outcomes
+
+Learner suggestions applied by CATS must be trace-linked to measurable outcomes and attributable accountability records.
+
+Enforcement:
+
+- suggestion IDs must map to CATS plans/runs and outcome metrics;
+- adverse impacts must map to originating learner decisions.
+
+### 8. Consortium Membership Must Be Merit-Based
+
+Consortium membership must be selected using merit, compliance, and relevance criteria, not static privilege.
+
+Enforcement:
+
+- membership rotation, eligibility checks, and bias controls are mandatory;
+- chair or member roles cannot be permanently fixed outside policy exceptions.
+
+### 9. System Must Remain Auditable
+
+Every critical decision, transition, and control action must be reconstructable from immutable audit artifacts.
+
+Enforcement:
+
+- all decisions require timestamps, actor identity, lineage keys, and reason codes;
+- deterministic replay support is required for incident and governance review.
+
+## Cross-Cutting Compliance Requirements
+
+- deny-by-default on policy ambiguity;
+- no subsystem may bypass governance or Zero-Trust gates via side channels;
+- violations must emit high-severity audit events and trigger corrective workflow.
+
+## Governance Conformance Statement
+
+Any subsystem behavior conflicting with these laws is non-conformant and must be blocked, quarantined, or remediated before production use.
+

--- a/docs/architecture/cognitive-mesh/CM-15-knowledge-packet-ledger.md
+++ b/docs/architecture/cognitive-mesh/CM-15-knowledge-packet-ledger.md
@@ -1,0 +1,129 @@
+# Knowledge Packet Ledger
+
+**Document ID:** CM-15  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Packet Lifecycle Events
+
+The Knowledge Packet Ledger records all material state transitions for every packet in the Cognitive Mesh.
+
+Required lifecycle events:
+
+- `packet.created`
+- `packet.validated`
+- `packet.authorized`
+- `packet.routed`
+- `packet.delivered`
+- `packet.acknowledged`
+- `packet.retried`
+- `packet.quarantined`
+- `packet.replayed`
+- `packet.expired`
+- `packet.closed`
+
+Event records must be append-only, timestamped, and linked to packet lineage keys.
+
+## 2. Traceability
+
+The ledger provides end-to-end packet traceability across producers, routers, tunnels, targets, and replay paths.
+
+Trace keys:
+
+- `packet_id`
+- `parent_packet_id`
+- `trace_id`
+- `span_id`
+- `correlation_id`
+- `tenant_id`
+- `session_id`
+- `branch_id` (for split-horizon delivery)
+
+Traceability requirements:
+
+- every hop must emit lineage-consistent events;
+- branch-level outcomes must map back to original packet identity;
+- replayed packets must preserve original and replay lineage links.
+
+## 3. Audit Trails
+
+The ledger is a primary audit source for governance, security, and incident review.
+
+Audit record requirements:
+
+- actor identity and role for each transition;
+- policy decisions and reason codes;
+- integrity validation outcomes;
+- authorization allow/deny outcomes;
+- destination and tunnel class decisions;
+- receipts and disposition status (`accepted`, `rejected`, `deferred`, `duplicate_dropped`, `quarantined`).
+
+Audit controls:
+
+- immutable storage with access control;
+- retention by governance class;
+- deterministic query support for forensic reconstruction.
+
+## 4. Replay Analysis
+
+Replay analysis uses ledger history to detect missing acknowledgements, inconsistent outcomes, and recovery candidates.
+
+Replay analysis capabilities:
+
+- identify lifecycle gaps between expected and observed states;
+- reconstruct packet flow timelines per topic, tenant, and branch;
+- compare original vs replay outcomes;
+- detect recurring failure patterns and repair effectiveness;
+- validate replay safety (no unauthorized or duplicate side effects).
+
+Replay outputs:
+
+- replay candidate sets;
+- replay directives with reason codes;
+- reconciliation status and closure evidence.
+
+## 5. Observability Metrics
+
+The ledger must emit and support metrics for lifecycle health and reliability.
+
+Core metrics:
+
+- `ledger_event_ingest_rate`
+- `ledger_write_latency_ms`
+- `packet_lifecycle_completion_rate`
+- `packet_ack_gap_rate`
+- `packet_replay_trigger_rate`
+- `packet_replay_success_rate`
+- `packet_quarantine_rate`
+- `packet_retry_rate`
+- `packet_end_to_end_latency_ms`
+- `packet_audit_query_latency_ms`
+
+Metric dimensions:
+
+- packet family
+- tunnel class
+- topic
+- tenant
+- destination class
+- lifecycle state
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    P[Packet Flow Events] --> I[Ledger Ingest]
+    I --> S[Immutable Event Store]
+    S --> T[Trace Query Layer]
+    S --> A[Audit Trail Layer]
+    S --> R[Replay Analysis Engine]
+    S --> M[Observability Metrics]
+    R --> D[Replay Directives]
+    A --> G[Governance/Security Review]
+```
+
+## Enforcement Statement
+
+No production packet flow is considered complete unless lifecycle events are ledgered, trace-linked, and queryable for audit and replay analysis.
+

--- a/docs/architecture/cognitive-mesh/CM-16-topic-review-registry.md
+++ b/docs/architecture/cognitive-mesh/CM-16-topic-review-registry.md
@@ -1,0 +1,121 @@
+# Topic Review Registry
+
+**Document ID:** CM-16  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Topic Creation Sources
+
+The Topic Review Registry accepts topics only from authorized upstream producers. The Expert Consortium can review topics but cannot originate them.
+
+Authorized source classes:
+
+- CATS execution anomaly and improvement detectors;
+- governance-triggered review directives;
+- learner suggestion escalation workflows;
+- operator-initiated review requests via approved control interfaces;
+- replay/incident analysis systems identifying unresolved decisions.
+
+Source requirements:
+
+- cryptographically verifiable source identity;
+- valid tenant/session and policy scope;
+- required evidence references at submission time or declared evidence acquisition plan.
+
+### Minimal Topic Schema
+
+Required fields:
+
+- `topic_id`
+- `tenant_id`
+- `topic_source`
+- `risk_class`
+- `state`
+- `created_at`
+- `last_reviewed_at`
+
+Required indexes:
+
+- `tenant_id`
+- `state`
+- `risk_class`
+
+## 2. Topic Lifecycle
+
+Each topic follows a governed lifecycle with auditable transitions.
+
+Lifecycle states:
+
+1. `submitted`
+2. `validated`
+3. `queued_for_review`
+4. `in_review`
+5. `decision_pending`
+6. `decided` (`approved`, `approved_with_conditions`, `rejected`, `deferred`)
+7. `closed` (implemented, archived, or revoked)
+
+Lifecycle rules:
+
+- every transition requires actor identity, timestamp, and reason code;
+- state transitions must pass governance and authorization checks;
+- deferred topics must carry explicit re-entry criteria and deadline metadata.
+
+## 3. Review History
+
+The registry preserves complete review history for each topic, including debate rounds, votes, dissent, and escalations.
+
+Required history records:
+
+- topic version snapshots;
+- consortium participant roster and role assignments;
+- debate artifacts and evidence references per round;
+- voting outcomes, quorum status, and confidence levels;
+- escalation events and final resolution path;
+- linked decision packet identifiers.
+
+History controls:
+
+- append-only history log with immutable event IDs;
+- deterministic ordering for replay and forensics;
+- branch-aware tracking for parallel review paths.
+
+## 4. Topic Evidence Storage
+
+Topic evidence storage holds structured references and integrity metadata for all artifacts used in review and decisioning.
+
+Stored evidence classes:
+
+- execution telemetry summaries;
+- benchmark and evaluation outputs;
+- governance findings;
+- external references admitted through policy;
+- replay and repair analysis artifacts.
+
+Storage requirements:
+
+- content-addressable artifact references with integrity hash;
+- provenance metadata (`source_id`, `captured_at`, `policy_tags`);
+- tenant/session/classification access controls;
+- retention and deletion by governance policy;
+- fast retrieval for audit, replay, and re-review workflows.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    SRC[Authorized Topic Sources] --> VAL[Validation + Policy Gate]
+    VAL --> REG[Topic Review Registry]
+    REG --> Q[Review Queue]
+    Q --> REV[Consortium Review]
+    REV --> DEC[Decision Packet]
+    DEC --> REG
+    REG --> HIST[Review History Store]
+    REG --> EVID[Topic Evidence Store]
+    EVID --> REV
+```
+
+## Enforcement Statement
+
+No topic may be reviewed, decided, or promoted in Cognitive Mesh workflows unless its source, lifecycle transitions, review history, and evidence references are fully registered and auditable.
+

--- a/docs/architecture/cognitive-mesh/CM-17-consortium-decision-registry.md
+++ b/docs/architecture/cognitive-mesh/CM-17-consortium-decision-registry.md
@@ -1,0 +1,115 @@
+# Consortium Decision Registry
+
+**Document ID:** CM-17  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Decision Packets
+
+The Consortium Decision Registry stores signed, immutable decision packets produced by Expert Consortium review workflows.
+
+Each decision packet must include:
+
+- `decision_id`
+- `topic_id`
+- `decision_type` (`approve`, `approve_with_conditions`, `reject`, `defer`)
+- `decision_timestamp`
+- `consortium_session_id`
+- `reason_summary`
+- `evidence_refs`
+- `governance_tags`
+- `integrity` (hash, signature, key reference)
+
+Storage rules:
+
+- only governance-admitted decision packets are persisted as authoritative;
+- packet lineage must link to topic review and evidence artifacts;
+- packet updates create new versions; prior versions remain immutable.
+
+## 2. Voting Results
+
+The registry stores full voting outcomes associated with each decision packet.
+
+Required voting artifacts:
+
+- quorum status and threshold policy;
+- role-weighted vote tally;
+- per-role vote dispositions;
+- confidence score and uncertainty band;
+- dissent entries with evidence references;
+- veto flags and veto rationale (if applicable).
+
+Voting records must be queryable by topic, role, decision window, and risk class.
+
+## 3. Conditions
+
+For conditional decisions, the registry stores explicit execution and compliance conditions.
+
+Condition fields:
+
+- `condition_id`
+- `condition_type` (technical, governance, operational, security)
+- `required_action`
+- `owner_principal`
+- `deadline_at`
+- `verification_criteria`
+- `status` (`open`, `met`, `failed`, `waived`)
+
+Condition rules:
+
+- conditional approvals are inactive until required condition state is satisfied per policy;
+- condition state changes require signed verification events;
+- unmet critical conditions can auto-trigger escalation or revocation workflows.
+
+## 4. Escalation History
+
+The registry maintains complete escalation lineage for decisions that could not be resolved at the initial consortium level.
+
+Escalation records include:
+
+- escalation trigger event and reason code;
+- escalation path (expanded panel, governance board, emergency control);
+- participant and authority changes;
+- intermediate outcomes and timestamps;
+- final resolution packet and closure status.
+
+Escalation controls:
+
+- all escalation transitions are append-only and audit-immutable;
+- escalation outcomes must link back to original `decision_id`;
+- superseded decisions remain accessible with explicit supersession metadata.
+
+## 5. Decision State Machine
+
+Canonical state transitions:
+
+- `proposed` -> `under_review` -> `approved`
+- `proposed` -> `under_review` -> `rejected`
+- `proposed` -> `under_review` -> `conditional` -> `executed`
+- `proposed` -> `under_review` -> `conditional` -> `expired`
+
+Timeout and escalation rules:
+
+- if `under_review` exceeds topic SLA window, emit `escalation.timeout.review` and escalate;
+- if `conditional` exceeds `deadline_at` with unmet required conditions, transition to `expired` and emit escalation event;
+- repeated deadlock or veto in `under_review` triggers governance-board escalation path;
+- every timeout or escalation transition must include reason code, actor/system identity, and timestamp.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    DP[Decision Packet] --> REG[Consortium Decision Registry]
+    VR[Voting Results] --> REG
+    COND[Conditions] --> REG
+    ESC[Escalation Events] --> REG
+    REG --> AUDIT[Audit/Query Layer]
+    REG --> GOV[Governance Gate Integrations]
+    GOV --> REG
+```
+
+## Enforcement Statement
+
+No consortium decision is operationally effective unless its packet, voting record, condition set, and escalation lineage are durably stored and auditable in the Consortium Decision Registry.
+

--- a/docs/architecture/cognitive-mesh/CM-18-learner-reputation-ledger.md
+++ b/docs/architecture/cognitive-mesh/CM-18-learner-reputation-ledger.md
@@ -1,0 +1,130 @@
+# Learner Reputation Ledger
+
+**Document ID:** CM-18  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Reputation Events
+
+The Learner Reputation Ledger is an immutable event store that records all evidence-backed reputation actions for learners across the Cognitive Mesh.
+
+Required reputation event types:
+
+- `reputation.evidence.accepted`
+- `reputation.evidence.rejected`
+- `reputation.score.recomputed`
+- `reputation.score.adjusted`
+- `reputation.tier.changed`
+- `reputation.penalty.applied`
+- `reputation.recovery.applied`
+- `reputation.override.denied`
+- `reputation.model.version_changed`
+
+Each event must include:
+
+- `event_id`
+- `learner_id`
+- `occurred_at`
+- `tenant_id`
+- `trace_id`
+- `reason_code`
+- `actor_id` (system/service/human principal)
+
+### Canonical Ledger Schema
+
+Required fields:
+
+- `event_id`
+- `learner_id`
+- `suggestion_id`
+- `evidence_type`
+- `source_system`
+- `impact_score`
+- `timestamp`
+- `schema_version`
+
+## 2. Audit Trails
+
+The ledger is a primary audit artifact for governance, security, and incident review.
+
+Audit requirements:
+
+- append-only write semantics with immutable event payloads;
+- cryptographic integrity checks on event records;
+- actor identity, policy ID, and decision reason on every event;
+- deterministic event ordering for replay investigations;
+- access-controlled query interfaces with read audit logs.
+
+Audit queries must support:
+
+- per learner timeline reconstruction;
+- per policy impact analysis;
+- cross-event correlation with packet and topic registries.
+
+## 3. Evidence Linking
+
+Every scoring-relevant event must link to verified evidence sources.
+
+Mandatory linkage fields:
+
+- `evidence_event_id` (REE identifier)
+- `packet_id`
+- `suggestion_id` (when applicable)
+- `decision_id` (consortium/governance linkage)
+- `baseline_ref`
+- `integrity_hash`
+
+Linking rules:
+
+- only verified and policy-compliant evidence can be scoring-eligible;
+- missing or broken links force non-scoring event status;
+- lineage links must remain stable across replay and recomputation.
+
+## 4. Score Change Tracking
+
+The ledger tracks every reputation score delta as an explicit, explainable change record.
+
+Required score-change fields:
+
+- `score_before`
+- `score_after`
+- `delta`
+- `dimension_breakdown` (outcome, evidence, calibration, compliance, operations, collaboration)
+- `window_profile` (short/medium/long window contributions)
+- `decay_applied`
+- `model_version`
+- `confidence_band`
+
+Tracking rules:
+
+- no in-place score mutation without a corresponding ledger event;
+- tier transitions must reference the exact score-change event;
+- recomputation must produce comparable deterministic outputs under the same model version.
+
+## 5. Schema Version Compatibility
+
+Versioning rules:
+
+- `schema_version` must follow semantic versioning (`MAJOR.MINOR.PATCH`);
+- consumers must reject unknown major versions;
+- consumers must ignore unknown optional fields for supported major versions;
+- producers must not remove required fields without a major version increment;
+- registry must retain compatibility readers for at least two previous minor versions.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    REE[Verified Rating Evidence Events] --> SC[Scoring Engine]
+    SC --> EV[Reputation Change Events]
+    EV --> L[Immutable Reputation Ledger]
+    L --> A[Audit Query Layer]
+    L --> R[Replay/Recompute Engine]
+    R --> L
+```
+
+## Enforcement Statement
+
+No Learner Rating or Learner Reputation profile is valid for routing, promotion, or consortium selection unless its evidence links and score deltas are immutably recorded in the Learner Reputation Ledger.
+

--- a/docs/architecture/cognitive-mesh/CM-19-architecture-roadmap.md
+++ b/docs/architecture/cognitive-mesh/CM-19-architecture-roadmap.md
@@ -1,0 +1,138 @@
+# Cognitive Mesh Architecture Roadmap
+
+**Document ID:** CM-19  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-07
+
+## Batch Completion Status
+
+### Batch-8 - Cognitive Experience Layer (CEL): Completed
+
+- structured experience record contract implemented;
+- outcome and circumstantial models added;
+- deterministic capture policy added;
+- in-memory repository and retrieval hooks added;
+- post-outcome runtime integration completed;
+- CEL documentation and tests committed.
+
+## 1. Phase 1 Transport Systems
+
+Objective: establish secure, low-latency packet transport foundations.
+
+Scope:
+
+- implement KPP envelope/payload validation baseline;
+- deploy messenger tunnel classes (`T0`, `T1`, `T2`, `T3`);
+- implement Zero-Trust gate, dedup ingress, and receipt protocol;
+- ship mesh router core with policy-aware tunnel selection;
+- establish packet ledger and transport observability.
+
+Exit criteria:
+
+- end-to-end packet flow stable under SLA targets;
+- mandatory authN/authZ/integrity checks active on all routes;
+- replay-capable transport path available via `T3`.
+
+## 2. Phase 2 Knowledge Systems
+
+Objective: operationalize SIL/IKL/EKL libraries and governed knowledge flow.
+
+Scope:
+
+- stand up SIL, IKL, and EKL stores with lineage indexing;
+- enable governed promotion and demotion workflows;
+- implement suggestion outcome registry and topic review registry;
+- integrate packet-ledger links into knowledge lifecycle events;
+- deliver retrieval/read APIs with scope-aware access control.
+
+Exit criteria:
+
+- SIL -> IKL -> EKL lifecycle operational with governance gates;
+- promotion, demotion, and revocation events fully auditable;
+- reuse tracking enabled for approved knowledge artifacts.
+
+## 3. Phase 3 Consortium Governance
+
+Objective: deploy formal consortium review and decision governance.
+
+Scope:
+
+- launch expert consortium debate and voting protocol;
+- implement decision packets, conditions, and escalation workflows;
+- deploy dynamic merit-based membership and chair constraints;
+- enforce consolidated governance laws across consortium interactions;
+- integrate decision registry with topic and evidence registries.
+
+Exit criteria:
+
+- high-impact decisions require consortium/governance path;
+- voting, dissent, and escalation trails are immutable and queryable;
+- membership rotation and bias controls enforced by policy.
+
+## 4. Phase 4 Learning Intelligence
+
+Objective: activate evidence-driven learning and reputation control loops.
+
+Scope:
+
+- deploy learner reputation engine with multi-window scoring;
+- operationalize Rating Evidence Events (REE) verification pipeline;
+- deploy learner reputation ledger and score explainability APIs;
+- integrate reputation outputs into routing and promotion decisions;
+- enforce learner accountability for CATS outcome impact.
+
+Exit criteria:
+
+- reputation updates are evidence-linked and replayable;
+- routing and promotion consume reputation tiers safely;
+- anti-gaming and anomaly detection controls active.
+
+## 5. Phase 5 Autonomous Discovery
+
+Objective: enable bounded self-evolving intelligence under strict governance.
+
+Scope:
+
+- enable autonomous topic discovery from runtime/replay signals;
+- automate candidate hypothesis generation and bounded trials;
+- expand adaptive routing from topic heatmaps and reputation feedback;
+- implement autonomous promotion recommendations with human override;
+- strengthen closed-loop discovery -> validation -> governance -> adoption.
+
+Exit criteria:
+
+- autonomous discovery operates within policy envelopes;
+- novel knowledge can be safely trialed and governed at scale;
+- system remains fully auditable with deterministic incident replay.
+
+## Milestone Governance and Controls
+
+- each phase requires formal readiness review before progression;
+- no phase can bypass Zero-Trust, governance, or auditability requirements;
+- cross-phase regression benchmarks must be passed before release.
+
+## Phase-to-Document Dependency Matrix
+
+| Phase | Primary Documents |
+| --- | --- |
+| Phase 1 Transport Systems | CM-02, CM-03, CM-04, CM-05, CM-06, CM-07, CM-15 |
+| Phase 2 Knowledge Systems | CM-08, CM-12, CM-16 |
+| Phase 3 Consortium Governance | CM-09, CM-10, CM-14, CM-17 |
+| Phase 4 Learning Intelligence | CM-11, CM-13, CM-18 |
+| Phase 5 Autonomous Discovery | CM-01, CM-19 (with governed integration of all prior phase capabilities) |
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    P1[Phase 1\nTransport Systems] --> P2[Phase 2\nKnowledge Systems]
+    P2 --> P3[Phase 3\nConsortium Governance]
+    P3 --> P4[Phase 4\nLearning Intelligence]
+    P4 --> P5[Phase 5\nAutonomous Discovery]
+```
+
+## Enforcement Statement
+
+Roadmap progression is conditional on security, governance, and audit conformance at each phase gate; capability expansion cannot outpace control maturity.
+

--- a/docs/architecture/cognitive-mesh/CM-26-intelligence-output-model.md
+++ b/docs/architecture/cognitive-mesh/CM-26-intelligence-output-model.md
@@ -1,0 +1,211 @@
+# RocketGPT Intelligence Output Model (IOM)
+
+**Document ID:** CM-26  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose of the Intelligence Output Model
+
+The Intelligence Output Model (IOM) defines how Cognitive Mesh reasoning is transformed into standardized, executable, and auditable outputs. Structured outputs are required to ensure:
+
+- deterministic handoff from reasoning to execution;
+- governance and Zero-Trust policy enforcement at each transition;
+- measurable outcomes for evaluation and Learner Rating evidence;
+- reliable conversion of outcomes into learning and memory artifacts.
+
+Without a standardized model, outputs become non-comparable, non-governable, and difficult to replay or learn from.
+
+## 2. Intelligence Cycle
+
+The Cognitive Mesh intelligence cycle:
+
+1. Observation  
+2. Context Building  
+3. Reasoning  
+4. Evaluation (Consortium when required)  
+5. Decision  
+6. Execution (CATS)  
+7. Outcome  
+8. Evidence Events  
+9. Learning  
+10. Memory
+
+Cycle rules:
+
+- each stage emits lineage-linked artifacts;
+- high-risk stages require governance and/or consortium controls;
+- cycle completion requires outcome and evidence emission, not only execution.
+
+## 3. Core Intelligence Outputs
+
+### 3.1 Decision Output
+
+Decision artifact representing selected intent, rationale, and constraints.
+
+```json
+{
+  "decision_id": "dec_01JZB4R9H3K7Q2D5M8T1C6P4N0",
+  "topic_id": "topic_plan_optimization_221",
+  "decision_type": "approve_with_conditions",
+  "rationale": "Retrieval-first path improves expected latency under current load.",
+  "constraints": ["latency_p95_lt_500ms", "governance_gate_required"],
+  "timestamp": "2026-03-06T13:02:14.221Z"
+}
+```
+
+### 3.2 Action Output
+
+Execution-ready action artifact derived from a decision.
+
+```json
+{
+  "action_id": "act_01JZB4T1K8P5A3C6R2M9D7F4Q1",
+  "decision_id": "dec_01JZB4R9H3K7Q2D5M8T1C6P4N0",
+  "workflow": "cats.plan.execute",
+  "inputs": {
+    "strategy": "retrieval_first",
+    "scope": "tenant_acme"
+  },
+  "authorization_scope": "cats.execute.plan",
+  "timestamp": "2026-03-06T13:03:06.440Z"
+}
+```
+
+### 3.3 Result Output
+
+Measured execution outcome artifact from CATS.
+
+```json
+{
+  "result_id": "res_01JZB4V4N2Q8M1D7C5R9T3F6K0",
+  "action_id": "act_01JZB4T1K8P5A3C6R2M9D7F4Q1",
+  "status": "success",
+  "metrics_before": { "plan_latency_ms": 410, "timeout_rate": 0.021 },
+  "metrics_after": { "plan_latency_ms": 334, "timeout_rate": 0.016 },
+  "governance_status": "approved",
+  "timestamp": "2026-03-06T13:03:42.993Z"
+}
+```
+
+### 3.4 Learning Output
+
+Learning artifact generated from result + evidence analysis.
+
+```json
+{
+  "learning_id": "lrn_01JZB4W9F6P2C8R1M5D7Q3T4A0",
+  "source_result_id": "res_01JZB4V4N2Q8M1D7C5R9T3F6K0",
+  "learning_type": "strategy_delta",
+  "proposed_change": "increase retrieval-first priority for similar contexts",
+  "confidence": 0.84,
+  "promotion_candidate": true,
+  "timestamp": "2026-03-06T13:04:17.118Z"
+}
+```
+
+## 4. Intelligence Output Pipeline
+
+Canonical pipeline:
+
+`Decision Packet -> Action Packet -> Execution (CATS) -> Result Packet -> Evidence Events -> Learning Packet -> Memory Fabric`
+
+Pipeline guarantees:
+
+- every transition preserves lineage (`decision_id`, `action_id`, `result_id`, trace IDs);
+- failures emit receipts and evidence events;
+- learning outputs are governed before promotion to durable knowledge.
+
+## 5. Output Packet Types
+
+IOM packet classes:
+
+- `DecisionPacket`
+- `ActionPacket`
+- `ExecutionPacket`
+- `ResultPacket`
+- `LearningPacket`
+
+KPP integration:
+
+- each IOM packet class is serialized and transported as a Knowledge Packet Protocol-compliant packet;
+- packet family mapping is policy-defined (`knowledge.bundle`, `knowledge.delta`, `knowledge.directive`, `knowledge.receipt`);
+- all required KPP envelope/integrity fields apply unchanged.
+
+Reference: [CM-02 Knowledge Packet Protocol](./CM-02-knowledge-packet-protocol.md)
+
+## 6. Governance and Zero-Trust
+
+All intelligence outputs must pass:
+
+- Zero-Trust validation;
+- governance policy checks;
+- execution authorization checks.
+
+No DecisionPacket, ActionPacket, ExecutionPacket, ResultPacket, or LearningPacket may bypass these controls.
+
+References:
+
+- [CM-05 Zero-Trust Messaging Architecture](./CM-05-zero-trust-messaging.md)
+- [CM-14 Consolidated Governance Rules](./CM-14-consolidated-governance-rules.md)
+
+## 7. Output Observability
+
+Required system metrics:
+
+- `decision_throughput`
+- `execution_success_rate`
+- `learning_rate`
+- `knowledge_promotion_rate`
+
+Metric rules:
+
+- metrics must be lineage-correlated to packet IDs and trace IDs;
+- metrics must be segmented by tenant, topic, and workflow class.
+
+## 8. Relationship with Memory Fabric
+
+IOM outputs generate memory classes in the Memory Fabric:
+
+- Result Output -> Result-Based Memory
+- Learning Output -> Cognitive Memory
+- Decision Output (consortium/governance) -> Consortium Decision Memory
+- Creative and exploratory learning artifacts -> Creative Memory
+
+These mappings convert operational intelligence into reusable governed memory substrate.
+
+References:
+
+- [CM-28 Memory Fabric Architecture](./CM-28-memory-fabric-architecture.md)
+- [CM-29 Memory Data Schemas](./CM-29-memory-schemas.md)
+
+## 9. Integration with CATS
+
+ActionPackets are the execution trigger contract for CATS workflows.
+
+Integration behavior:
+
+- ActionPacket is authorized and routed to CATS execution endpoints;
+- CATS executes declared workflow with scoped inputs;
+- CATS emits ExecutionPacket/ResultPacket plus receipts and evidence events;
+- resulting artifacts flow into learning and Memory Fabric stages.
+
+## 10. Architecture Diagram
+
+```mermaid
+flowchart LR
+    OBS[Observation + Context] --> RSN[Reasoning]
+    RSN --> EVAL[Evaluation / Consortium]
+    EVAL --> DP[DecisionPacket]
+    DP --> AP[ActionPacket]
+    AP --> CATS[CATS Execution]
+    CATS --> EP[ExecutionPacket]
+    EP --> RP[ResultPacket]
+    RP --> EV[Evidence Events]
+    EV --> LP[LearningPacket]
+    LP --> MF[Memory Fabric]
+```
+
+## Enforcement Statement
+
+The Intelligence Output Model is the mandatory contract for converting reasoning into governed execution, measurable outcomes, and reusable memory. Outputs that do not comply with IOM, KPP, Zero-Trust, and governance controls are non-conformant.

--- a/docs/architecture/cognitive-mesh/CM-27-dream-engine-architecture.md
+++ b/docs/architecture/cognitive-mesh/CM-27-dream-engine-architecture.md
@@ -1,0 +1,154 @@
+# RocketGPT Dream Engine Architecture
+
+**Document ID:** CM-27  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose
+
+The Dream Engine is RocketGPT's offline cognition subsystem. It executes non-interactive "dream cycles" to discover patterns, synthesize creative hypotheses, and consolidate memory without direct user interaction.
+
+Purpose outcomes:
+
+- improve intelligence quality from accumulated memory and outcomes;
+- generate speculative insights in a controlled offline path;
+- prepare reviewable proposals for consortium and governance workflows.
+
+## 2. Dream Cycle Triggers
+
+Dream cycles run when one or more triggers are met:
+
+- scheduled intervals;
+- system idle periods;
+- large knowledge ingestion events;
+- high volume of execution outcomes;
+- major consortium decisions.
+
+Trigger policy is governance-configurable and tenant-aware.
+
+## 3. Dream Engine Components
+
+### Dream Scheduler
+
+Selects run windows, workload budgets, and trigger eligibility.
+
+### Memory Replay Engine
+
+Replays relevant Memory Fabric records and lineage for analysis.
+
+### Pattern Discovery Engine
+
+Finds recurrent associations, anomalies, and success/failure motifs.
+
+### Simulation Engine
+
+Runs bounded what-if evaluations on candidate ideas and inferred strategies.
+
+### Creative Synthesizer
+
+Combines patterns and contexts to generate novel but constrained hypotheses.
+
+### Dream Insight Generator
+
+Produces structured Dream Insights and emits them to Dream Memory.
+
+## 4. Dream Processing Pipeline
+
+`Dream Trigger -> Memory Replay -> Pattern Discovery -> Simulation / Creative Synthesis -> Dream Insight -> Dream Memory -> Topic Proposal -> Consortium Review`
+
+Pipeline guarantees:
+
+- all stages are offline and non-executing;
+- all outputs are lineage-linked to source memory;
+- no stage can directly write EKL or trigger direct execution.
+
+## 5. Dream Memory
+
+Dream Memory is a dedicated memory type for speculative offline cognition outputs.
+
+Dream Insight tags:
+
+- `hypothesis`
+- `pattern`
+- `simulation`
+- `creative`
+
+Dream insights remain speculative until validated because they are inference products, not direct operational evidence. They require review and policy approval before promotion to governed knowledge.
+
+## 6. Dream Insight Schema
+
+```json
+{
+  "dream_insight_id": "drm_01JZB9W3P8R2M6C4T1A7D5F9K0",
+  "type": "hypothesis",
+  "confidence": 0.71,
+  "topic": "routing_efficiency_under_burst_load",
+  "generated_from": [
+    "pat_01JZA1V3Y8M2Q6H4T1R9C7N5L0",
+    "res_01JZA1Q2S8X4M2F7A9D0P3T6N4"
+  ],
+  "timestamp": "2026-03-06T14:05:12.776Z"
+}
+```
+
+## 7. Dream Safety Rules
+
+Dream outputs must never:
+
+- modify EKL directly;
+- execute CATS workflows;
+- modify Learner Ratings;
+- bypass governance.
+
+Dream outputs may only produce topic proposals for consortium review.
+
+## 8. Dream Lifecycle
+
+`Dream Insight -> Dream Memory -> Topic Review Packet -> Consortium Evaluation -> Possible Knowledge Promotion`
+
+Lifecycle controls:
+
+- promotion is conditional on evidence-backed validation;
+- governance gates are mandatory for any durable knowledge transition;
+- rejected insights remain non-authoritative and may be archived.
+
+## 9. Metrics
+
+Required Dream Engine metrics:
+
+- `dream_insights_generated`
+- `insights_promoted`
+- `insights_rejected`
+- `insight_accuracy`
+
+Metrics must be tracked by dream type, topic class, and validation outcome.
+
+## 10. Architecture Placement
+
+```mermaid
+flowchart TD
+    MF[Memory Fabric]
+    DE[Dream Engine]
+    DI[Dream Insights]
+    TR[Topic Registry]
+    CONS[Consortium]
+    GOV[Governance]
+
+    MF --> DE
+    DE --> DI
+    DI --> TR
+    TR --> CONS
+    CONS --> GOV
+```
+
+## Related Specifications
+
+- [CM-26 Intelligence Output Model](./CM-26-intelligence-output-model.md)
+- [CM-28 Memory Fabric Architecture](./CM-28-memory-fabric-architecture.md)
+- [CM-16 Topic Review Registry](./CM-16-topic-review-registry.md)
+- [CM-14 Consolidated Governance Rules](./CM-14-consolidated-governance-rules.md)
+
+## Enforcement Statement
+
+The Dream Engine is an offline proposal system only. It must remain Zero-Trust governed, execution-isolated, and non-authoritative until consortium and governance validation is complete.

--- a/docs/architecture/cognitive-mesh/CM-28-memory-fabric-architecture.md
+++ b/docs/architecture/cognitive-mesh/CM-28-memory-fabric-architecture.md
@@ -1,0 +1,158 @@
+# RocketGPT Memory Fabric Architecture
+
+**Document ID:** CM-28  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose
+
+RocketGPT requires a unified Memory Fabric to prevent fragmentation of intelligence across isolated stores. Cognitive Mesh components produce correlated outputs (reasoning traces, execution outcomes, governance decisions, consortium judgments, and dream insights) that must remain lineage-linked and queryable as one knowledge substrate.
+
+A unified fabric is required to:
+
+- preserve cross-domain context and causality;
+- avoid duplicated or conflicting memory states across subsystems;
+- support governed learning and replay-safe auditability;
+- enable low-latency retrieval for active execution and long-horizon refinement.
+
+## 2. Memory Classes
+
+### Working Memory
+
+Stores short-lived task/session context for active reasoning and execution.  
+Retention: ephemeral; expires at session end or short TTL.
+
+### Recall Memory
+
+Stores retrievable historical facts, prior outcomes, and reusable context fragments.  
+Retention: medium to long; subject to relevance and governance retention policies.
+
+### Creative Memory
+
+Stores divergent hypotheses, alternative strategies, and novel idea paths.  
+Retention: medium; promoted or pruned based on evidence and quality scoring.
+
+### Result-Based Memory
+
+Stores execution outcomes, metrics deltas, and result-linked evidence bundles.  
+Retention: long for high-impact outcomes; otherwise policy-governed archival.
+
+### Consortium Decision Memory
+
+Stores consortium decision packets, vote summaries, conditions, and escalation lineage.  
+Retention: long; audit-grade immutable retention.
+
+### Cognitive Memory
+
+Stores distilled reasoning abstractions, successful patterns, and reusable cognitive strategies.  
+Retention: long; governed promotion from candidate to validated memory.
+
+### Dream Memory
+
+Stores Dream Engine outputs including dream insights, synthetic hypotheses, and exploratory associations.  
+Retention: medium by default; promoted only through governance-approved validation paths.
+
+### Governance Memory
+
+Stores policy decisions, gate outcomes, compliance artifacts, and revocation history.  
+Retention: long; immutable audit-compliant retention.
+
+### Relationship Memory
+
+Stores cross-entity linkage graphs (topic-to-decision, suggestion-to-outcome, evidence-to-rating impact).  
+Retention: long; maintained with lineage integrity constraints.
+
+## 3. Memory Flow
+
+Memory write flow follows the Cognitive Mesh learning chain:
+
+`Decision Output -> Action Execution -> Result Output -> Evidence Events -> Learning Output -> Memory Fabric`
+
+Flow behavior:
+
+- each stage emits lineage-linked packets/events;
+- memory writes are accepted only after integrity, scope, and governance validation;
+- writes can produce signal or candidate records before validation promotion.
+
+Reference: [CM-26](./CM-26-decision-to-learning-pipeline.md)
+
+## 4. Memory Governance
+
+All Memory Fabric writes must satisfy:
+
+- Zero-Trust message validation and authorization controls;
+- governance policy gates for classification, retention, and promotion eligibility;
+- tenant/session isolation and least-privilege access.
+
+No memory object may bypass validation, and no write is authoritative without policy-admitted evidence.
+
+References:
+
+- [CM-05 Zero-Trust Messaging Architecture](./CM-05-zero-trust-messaging.md)
+- [CM-14 Consolidated Governance Rules](./CM-14-consolidated-governance-rules.md)
+
+## 5. Memory Lifecycle
+
+### signal
+
+Initial low-confidence memory signal emitted from runtime or learning events.
+
+### candidate memory
+
+Structured memory candidate with evidence links, awaiting validation.
+
+### validated memory
+
+Governance-approved, evidence-backed memory eligible for operational reuse.
+
+### archived memory
+
+Historical or superseded memory retained for replay, audit, and long-term analysis.
+
+Lifecycle transitions are policy-controlled and fully auditable.
+
+## 6. Memory Storage Layers
+
+### Hot Memory
+
+Low-latency active layer for current sessions and high-frequency retrieval.  
+Performance goal: millisecond-class reads/writes for active Cognitive Mesh paths.
+
+### Warm Memory
+
+Balanced layer for frequently reused validated knowledge and nearline historical context.  
+Performance goal: low-latency retrieval with higher durability and indexing depth.
+
+### Cold Memory
+
+Durable archival layer for replay, compliance, and longitudinal intelligence analysis.  
+Performance goal: throughput and durability over immediate latency.
+
+## 7. Integration with Dream Engine
+
+Dream Engine consumes curated Memory Fabric inputs (validated memory + selected candidate signals) to generate Dream Insights, synthetic hypotheses, and exploratory associations.
+
+Integration rules:
+
+- Dream Engine reads are scope- and policy-constrained;
+- Dream outputs are written as Dream Memory candidates, not auto-validated truths;
+- promotion of dream-derived insights requires evidence-backed validation and governance approval.
+
+Reference: [CM-27](./CM-27-dream-engine-architecture.md)
+
+## 8. Architecture Diagram
+
+```mermaid
+flowchart LR
+    CM[Cognitive Mesh] --> MF[Memory Fabric]
+    KL[Knowledge Libraries EKL/IKL/SIL] <--> MF
+    MF --> DE[Dream Engine]
+    DE --> DI[Dream Insights]
+    DI --> MF
+    MF --> CM
+```
+
+## Enforcement Statement
+
+The Memory Fabric is the authoritative, governed memory substrate for Cognitive Mesh intelligence continuity. All memory writes and promotions must remain Zero-Trust validated, evidence-linked, and audit-replayable.

--- a/docs/architecture/cognitive-mesh/CM-29-memory-schemas.md
+++ b/docs/architecture/cognitive-mesh/CM-29-memory-schemas.md
@@ -1,0 +1,184 @@
+# RocketGPT Memory Data Schemas
+
+**Document ID:** CM-29  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Result Memory Schema
+
+### Canonical Fields
+
+- `result_id` (string, required)
+- `action_id` (string, required)
+- `metrics_before` (object, required)
+- `metrics_after` (object, required)
+- `governance_status` (string, required)
+- `timestamp` (string, ISO-8601 UTC, required)
+
+### JSON Example
+
+```json
+{
+  "result_id": "res_01JZA1Q2S8X4M2F7A9D0P3T6N4",
+  "action_id": "act_plan_execute_4821",
+  "metrics_before": {
+    "plan_latency_ms": 412,
+    "timeout_rate": 0.021
+  },
+  "metrics_after": {
+    "plan_latency_ms": 336,
+    "timeout_rate": 0.016
+  },
+  "governance_status": "approved",
+  "timestamp": "2026-03-06T12:10:45.117Z"
+}
+```
+
+## 2. Creative Memory Schema
+
+### Canonical Fields
+
+- `creative_id` (string, required)
+- `idea_summary` (string, required)
+- `origin_context` (object, required)
+- `status` (enum: `adopted`, `deferred`, `rejected`, required)
+- `confidence` (number, 0.0-1.0, required)
+- `timestamp` (string, ISO-8601 UTC, required)
+
+### JSON Example
+
+```json
+{
+  "creative_id": "crv_01JZA1R5N6V9B1C4E8K2Q7M0H3",
+  "idea_summary": "Use staged retrieval before synthesis for low-latency planning.",
+  "origin_context": {
+    "session_id": "sess_6f9f2f03c85d",
+    "task_type": "plan_generation"
+  },
+  "status": "deferred",
+  "confidence": 0.74,
+  "timestamp": "2026-03-06T12:14:02.590Z"
+}
+```
+
+## 3. Consortium Decision Memory Schema
+
+### Canonical Fields
+
+- `decision_id` (string, required)
+- `topic_id` (string, required)
+- `participants` (array of objects, required)
+- `arguments` (array of strings, required)
+- `objections` (array of strings, required)
+- `final_decision` (string, required)
+- `rationale` (string, required)
+- `conditions` (array of objects, required)
+- `timestamp` (string, ISO-8601 UTC, required)
+
+### JSON Example
+
+```json
+{
+  "decision_id": "dec_01JZA1T0K2R8A7M4N9P1D5F3W6",
+  "topic_id": "topic_routing_drift_992",
+  "participants": [
+    { "id": "expert.ops.1", "role": "Systems Expert" },
+    { "id": "expert.risk.2", "role": "Risk Expert" }
+  ],
+  "arguments": [
+    "Adaptive thresholding reduces fallback spikes.",
+    "Evidence supports lower timeout rate under constrained load."
+  ],
+  "objections": [
+    "Insufficient cross-tenant validation sample."
+  ],
+  "final_decision": "approve_with_conditions",
+  "rationale": "Expected reliability gain with bounded rollout safeguards.",
+  "conditions": [
+    {
+      "condition_id": "cond_102",
+      "required_action": "Run staged rollout at 10 percent traffic for 24h."
+    }
+  ],
+  "timestamp": "2026-03-06T12:20:18.901Z"
+}
+```
+
+## 4. Cognitive Memory Schema
+
+### Canonical Fields
+
+- `pattern_id` (string, required)
+- `pattern_type` (string, required)
+- `success_rate` (number, 0.0-1.0, required)
+- `contexts_used` (array of strings, required)
+- `timestamp` (string, ISO-8601 UTC, required)
+
+### JSON Example
+
+```json
+{
+  "pattern_id": "pat_01JZA1V3Y8M2Q6H4T1R9C7N5L0",
+  "pattern_type": "retrieval_first_planning",
+  "success_rate": 0.86,
+  "contexts_used": [
+    "plan_generation",
+    "incident_triage"
+  ],
+  "timestamp": "2026-03-06T12:24:33.224Z"
+}
+```
+
+## 5. Dream Memory Schema
+
+### Canonical Fields
+
+- `dream_id` (string, required)
+- `dream_type` (string, required)
+- `confidence` (number, 0.0-1.0, required)
+- `generated_from` (array of strings, required)
+- `timestamp` (string, ISO-8601 UTC, required)
+
+### JSON Example
+
+```json
+{
+  "dream_id": "drm_01JZA1W8F9A3D2K7M4P6R0T5Q1",
+  "dream_type": "cross-domain hypothesis",
+  "confidence": 0.63,
+  "generated_from": [
+    "pat_01JZA1V3Y8M2Q6H4T1R9C7N5L0",
+    "res_01JZA1Q2S8X4M2F7A9D0P3T6N4"
+  ],
+  "timestamp": "2026-03-06T12:27:11.037Z"
+}
+```
+
+## 6. Relationship Memory Schema
+
+### Canonical Fields
+
+- `source_entity` (string, required)
+- `target_entity` (string, required)
+- `relationship_type` (string, required)
+- `weight` (number, 0.0-1.0, required)
+- `timestamp` (string, ISO-8601 UTC, required)
+
+### JSON Example
+
+```json
+{
+  "source_entity": "sugg_74c0b2",
+  "target_entity": "res_01JZA1Q2S8X4M2F7A9D0P3T6N4",
+  "relationship_type": "produced_result",
+  "weight": 0.92,
+  "timestamp": "2026-03-06T12:31:55.412Z"
+}
+```
+
+## Schema Conformance Notes
+
+- All schema instances must pass Zero-Trust and governance validation before persistence.
+- `timestamp` values must be UTC ISO-8601.
+- Unknown optional fields are permitted only under backward-compatible schema evolution policy.

--- a/docs/architecture/cognitive-mesh/CM-30-memory-retrieval-engine.md
+++ b/docs/architecture/cognitive-mesh/CM-30-memory-retrieval-engine.md
@@ -1,0 +1,107 @@
+# RocketGPT Memory Retrieval Engine
+
+**Document ID:** CM-30  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Retrieval Goals
+
+The Memory Retrieval Engine provides relevant intelligence from the Memory Fabric to active reasoning and control flows with minimal latency and governed confidence.
+
+Primary goals:
+
+- return context-appropriate memory with deterministic ranking;
+- preserve evidence and governance constraints at retrieval time;
+- minimize retrieval overhead on critical reasoning paths;
+- support explainable, trace-linked memory injection.
+
+## 2. Retrieval Modes
+
+### Context Retrieval
+
+Retrieves session/task-relevant memory fragments for immediate planning and execution context.
+
+### Pattern Retrieval
+
+Retrieves Cognitive Memory patterns with historical success signatures and usage contexts.
+
+### Outcome Retrieval
+
+Retrieves Result-Based Memory records and associated metrics deltas for expected outcome estimation.
+
+### Decision Retrieval
+
+Retrieves Consortium Decision Memory and Governance Memory artifacts for policy-constrained adjudication.
+
+### Creative Retrieval
+
+Retrieves Creative Memory and eligible Dream Memory candidates for bounded hypothesis generation.
+
+## 3. Retrieval Pipeline
+
+Canonical pipeline:
+
+`Query -> Context expansion -> Memory ranking -> Evidence filtering -> Memory injection`
+
+Stage behavior:
+
+- **Query:** caller submits intent, scope, and constraints.
+- **Context expansion:** engine enriches query with lineage, task, and policy context.
+- **Memory ranking:** candidate memories are scored and ordered.
+- **Evidence filtering:** non-compliant or low-evidence candidates are removed.
+- **Memory injection:** selected memory bundle is injected into downstream consumer context.
+
+## 4. Ranking Strategy
+
+Ranking combines weighted factors with policy-aware filtering.
+
+Ranking factors:
+
+- **Relevance score:** semantic fit to query intent and execution scope.
+- **Recency:** stronger preference for recent validated memory when quality is comparable.
+- **Outcome success rate:** preference for memory linked to higher measured success.
+- **Governance approval:** preference and eligibility gating for governance-approved memory.
+
+Ranking constraints:
+
+- unapproved or revoked memory cannot outrank validated memory;
+- tenant/session scope violations produce hard exclusion;
+- ranking outputs must include explainability metadata.
+
+## 5. Retrieval Integration
+
+### Reasoning Planner
+
+Retrieval supplies context, patterns, and outcomes to improve planning quality and reduce repeated failure paths.
+
+### Mesh Router
+
+Retrieval provides route-affecting knowledge (for example topic behavior and prior outcomes) for policy-aware dispatch optimization.
+
+### Consortium Review
+
+Retrieval provides decision history, objections, conditions, and evidence lineage to accelerate structured review.
+
+## 6. Performance Targets
+
+- Memory retrieval latency target: `< 50 ms` end-to-end for interactive paths.
+- p95 target applies to `Query -> Memory injection` lifecycle.
+- degraded-mode fallback must still return bounded, governance-safe memory context.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    Q[Query] --> CE[Context Expansion]
+    CE --> MR[Memory Ranking]
+    MR --> EF[Evidence Filtering]
+    EF --> MI[Memory Injection]
+    MI --> RP[Reasoning Planner]
+    MI --> R[Mesh Router]
+    MI --> CR[Consortium Review]
+```
+
+## Enforcement Statement
+
+The Memory Retrieval Engine must return low-latency, evidence-filtered, governance-compliant memory outputs suitable for direct use in reasoning, routing, and consortium workflows.

--- a/docs/architecture/cognitive-mesh/CM-31-memory-promotion-and-decay.md
+++ b/docs/architecture/cognitive-mesh/CM-31-memory-promotion-and-decay.md
@@ -1,0 +1,100 @@
+# Memory Promotion and Decay
+
+**Document ID:** CM-31  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Promotion
+
+Memory promotion defines how knowledge progresses from transient signals to durable reusable intelligence.
+
+Canonical path:
+
+`Signal -> IKL -> EKL`
+
+Promotion behavior:
+
+- signals are first captured as candidate memory;
+- validated candidates may be promoted into IKL for governed intermediate reuse;
+- proven, policy-approved memory is promoted from IKL to EKL for durable broad reuse.
+
+## 2. Promotion Criteria
+
+A memory object is eligible for promotion only when all required criteria are satisfied.
+
+### Outcome Success
+
+- linked outcomes show measurable positive impact against baseline;
+- no unresolved high-severity regressions in relevant contexts.
+
+### Repetition
+
+- memory demonstrates repeatable effectiveness across sufficient usage instances;
+- isolated one-off success is insufficient for durable promotion.
+
+### Governance Approval
+
+- governance gates approve policy, scope, retention, and compliance posture;
+- promotion decisions are recorded with evidence and reason codes.
+
+## 3. Decay
+
+Unused or weakly performing memory gradually decays in retrieval importance over time.
+
+Decay rules:
+
+- low-usage memory weight decreases with inactivity windows;
+- repeated low-value outcomes accelerate decay;
+- recent high-quality outcomes can counter decay and restore rank.
+
+Decay affects ranking and retrieval priority, not immutable historical audit records.
+
+## 4. Archiving
+
+Old or superseded knowledge is moved to cold storage for long-term retention and replay use.
+
+Archiving triggers:
+
+- sustained inactivity beyond policy threshold;
+- supersession by higher-quality or newer validated memory;
+- lifecycle end under retention policy.
+
+Archiving rules:
+
+- archived memory remains lineage-linked and queryable for audit/replay;
+- archived memory is excluded from hot-path retrieval unless explicitly requested.
+
+## 5. Memory Cleanup
+
+Memory cleanup ensures coherence, efficiency, and consistency of the Memory Fabric.
+
+### Duplicate Removal
+
+- exact and semantic duplicate memories are merged or removed using dedup policies;
+- cleanup preserves anchor lineage and evidence references.
+
+### Contradiction Resolution
+
+- conflicting memory artifacts are detected through evidence and outcome comparison;
+- governance or consortium adjudication determines retain/demote/revoke action;
+- resolved outcomes are recorded with traceable decision lineage.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    S[Signal] --> IKL[IKL]
+    IKL --> EKL[EKL]
+    IKL --> D[Decay Engine]
+    EKL --> D
+    D --> A[Archive Cold Storage]
+    IKL --> C[Cleanup]
+    EKL --> C
+    C --> IKL
+    C --> EKL
+```
+
+## Enforcement Statement
+
+Memory promotion, decay, archiving, and cleanup must remain evidence-driven, governance-controlled, and auditable across all lifecycle transitions.

--- a/docs/architecture/cognitive-mesh/CM-32-cognitive-memory-graph.md
+++ b/docs/architecture/cognitive-mesh/CM-32-cognitive-memory-graph.md
@@ -1,0 +1,114 @@
+# RocketGPT Cognitive Memory Graph
+
+**Document ID:** CM-32  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Graph Purpose
+
+RocketGPT requires a connected memory graph so intelligence can be reasoned over as relationships, not isolated records. Standalone records lose causality across suggestions, execution, decisions, results, and dream insights.
+
+The graph model is required to:
+
+- preserve end-to-end lineage across Cognitive Mesh events;
+- enable cross-entity reasoning and pattern discovery;
+- support explainable impact tracing (who/what caused outcomes);
+- improve retrieval and enrichment by traversing relationship context.
+
+## 2. Graph Nodes
+
+### Topic
+
+Represents review or operational focus areas entering the mesh.
+
+### Learner
+
+Represents learner entities producing suggestions and adaptations.
+
+### CAT
+
+Represents CATS execution entities/plans/runs linked to actions.
+
+### Decision
+
+Represents consortium or governance decision artifacts.
+
+### Result
+
+Represents execution outcomes and measured impact records.
+
+### Dream Insight
+
+Represents Dream Engine-generated hypotheses and synthesized insights.
+
+### Knowledge Entry
+
+Represents reusable knowledge artifacts (SIL/IKL/EKL-linked entries).
+
+## 3. Graph Edges
+
+Canonical edge types:
+
+- `suggested_by` (knowledge/topic/action -> learner)
+- `executed_by` (action/plan -> CAT)
+- `validated_by` (decision/knowledge/result -> governance or consortium decision node)
+- `resulted_in` (action/decision/suggestion -> result)
+- `influenced_by` (decision/result/knowledge -> dream insight, prior knowledge, or topic)
+
+Edge rules:
+
+- all edges must be timestamped and lineage-linked;
+- cross-tenant edges are disallowed unless explicitly policy-authorized;
+- edge writes must pass Zero-Trust validation and governance checks.
+
+## 4. Graph Queries
+
+### Find decisions that improved outcomes
+
+Traverse: `Decision -> resulted_in -> Result` with positive outcome delta filters.
+
+### Find learners linked to successful actions
+
+Traverse: `Learner <- suggested_by - Action -> executed_by -> CAT -> resulted_in -> Result` with success constraints.
+
+### Find creative ideas that later succeeded
+
+Traverse: `Dream Insight/Knowledge Entry -> influenced_by -> Decision/Action -> resulted_in -> Result` with time-windowed success checks.
+
+Query requirements:
+
+- all queries must support evidence back-links and explainable traversal paths;
+- query outputs must be scope-filtered by tenant/session and governance policy.
+
+## 5. Graph Integration
+
+### Pattern Discovery
+
+Graph traversal exposes recurring successful structures across topics, learners, decisions, and results.
+
+### Dream Engine
+
+Dream Engine uses graph neighborhoods to synthesize new associations, candidate hypotheses, and exploration paths.
+
+### Reasoning Enrichment
+
+Reasoning systems consume graph-derived context to prioritize high-probability actions and avoid repeated failure chains.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    T[Topic] -->|suggested_by| L[Learner]
+    L -->|influenced_by| K[Knowledge Entry]
+    K -->|validated_by| D[Decision]
+    D -->|resulted_in| R[Result]
+    C[CAT] -->|executed_by| R
+    DI[Dream Insight] -->|influenced_by| D
+    DI -->|influenced_by| K
+    R -->|influenced_by| K
+```
+
+## Enforcement Statement
+
+The Cognitive Memory Graph is the authoritative relationship layer for Memory Fabric intelligence lineage. Node and edge operations must remain Zero-Trust validated, governance-controlled, and auditable.

--- a/docs/architecture/cognitive-mesh/CM-33-cognitive-heatmap-system.md
+++ b/docs/architecture/cognitive-mesh/CM-33-cognitive-heatmap-system.md
@@ -1,0 +1,147 @@
+# RocketGPT Cognitive Heatmap System
+
+**Document ID:** CM-33  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose
+
+The Cognitive Heatmap System is the visualization and analytics subsystem for intelligence activity across the Cognitive Mesh.
+
+It is required to:
+
+- visualize intelligence activity in near real time;
+- detect emerging topics and acceleration zones;
+- identify high-impact learners and contribution clusters;
+- detect risk concentrations and failure hotspots;
+- guide consortium attention toward high-value or high-risk review targets.
+
+## 2. Heatmap Dimensions
+
+The heatmap represents activity across:
+
+- topics
+- learners
+- CATS workflows
+- decisions
+- results
+- dream insights
+
+Each dimension is sliceable by tenant, time window, and governance scope.
+
+## 3. Heatmap Metrics
+
+Measurable signals:
+
+- `topic_activity` (volume + growth trend)
+- `execution_success_rate`
+- `creative_idea_generation`
+- `dream_insights_frequency`
+- `risk_flags`
+- `governance_interventions`
+
+Metric requirements:
+
+- metrics must be lineage-linked and replay-consistent;
+- metric windows must support short, medium, and long horizon analysis.
+
+## 4. Heatmap Data Sources
+
+Heatmap signals originate from:
+
+- Knowledge Packets
+- Result Outputs
+- Evidence Events
+- Dream Insights
+- Consortium Decisions
+
+All source ingestion must pass Zero-Trust validation and policy scope checks before aggregation.
+
+## 5. Heatmap Views
+
+### Topic Heatmap
+
+Shows activity intensity, trend velocity, and decision density by topic.
+
+### Learner Heatmap
+
+Shows learner contribution impact, outcome quality, and risk signal concentration.
+
+### Execution Heatmap
+
+Shows CATS workflow throughput, success/failure ratios, and latency/risk hotspots.
+
+### Risk Heatmap
+
+Shows clustered risk flags, governance escalations, and unresolved anomaly regions.
+
+### Creative Activity Heatmap
+
+Shows creative idea and dream insight generation, validation progression, and rejection/promotions.
+
+## 6. Alerting
+
+The heatmap must detect and alert on:
+
+- sudden surge in risky ideas;
+- repeated execution failures;
+- governance escalation spikes.
+
+Alert behavior:
+
+- threshold- and trend-based triggers;
+- severity classification (`info`, `warning`, `critical`);
+- trace-linked alert payloads for investigation and replay.
+
+## 7. Anomaly-to-Risk Handoff Contract
+
+Handoff rules:
+
+- Cognitive Heatmap detects anomalies and concentration patterns.
+- Risk Management evaluates whether a detected anomaly constitutes a classified risk event.
+- Heatmap does not directly classify final risk severity without Risk Management evaluation.
+
+## 8. Integration
+
+### Mesh Router
+
+Heatmap trends provide topic pressure and risk signals for route shaping and prioritization.
+
+### Consortium Prioritization
+
+Heatmap hotspots guide which topics should be reviewed first by the consortium.
+
+### Dream Engine
+
+Heatmap activity patterns help seed dream-cycle focus areas and simulation priorities.
+
+### Risk Management
+
+Heatmap anomaly zones feed governance and incident workflows for mitigation and control actions.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    KP[Knowledge Packets] --> HS[Heatmap Signal Pipeline]
+    RO[Result Outputs] --> HS
+    EV[Evidence Events] --> HS
+    DI[Dream Insights] --> HS
+    CD[Consortium Decisions] --> HS
+    HS --> HM[Cognitive Heatmap Views]
+    HM --> MR[Mesh Router]
+    HM --> CP[Consortium Prioritization]
+    HM --> DE[Dream Engine]
+    HM --> RM[Risk Management]
+```
+
+## Enforcement Statement
+
+The Cognitive Heatmap System is an analytics and prioritization subsystem only. It must remain evidence-driven, governance-scoped, and auditable, and it must not directly mutate ratings, EKL state, or governance decisions.
+
+## Related Specifications
+
+- [CM-34 Risk Management and Mitigation Framework](./CM-34-risk-management-framework.md)
+- [CM-37 Cognitive Stability System](./CM-37-cognitive-stability-system.md)
+- [CM-40 Cognitive Life Cycle Management](./CM-40-cognitive-life-cycle-management.md)

--- a/docs/architecture/cognitive-mesh/CM-34-risk-management-framework.md
+++ b/docs/architecture/cognitive-mesh/CM-34-risk-management-framework.md
@@ -1,0 +1,194 @@
+# RocketGPT Risk Management and Mitigation Framework
+
+**Document ID:** CM-34  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose
+
+Risk management is required because RocketGPT is a creative cognitive system that can generate high-value innovations and high-impact failure modes in the same operating envelope. Without explicit controls, speculative reasoning, autonomous adaptation, and execution pathways can create operational, governance, and security exposure.
+
+This framework provides:
+
+- consistent risk identification across cognitive and execution layers;
+- measurable risk scoring for prioritization and control;
+- policy-bound mitigation and escalation workflows;
+- auditable accountability through a dedicated Risk Ledger.
+
+## 2. Risk Categories
+
+### Operational Risk
+
+Risks to reliability, latency, throughput, and service stability.
+
+### Governance Risk
+
+Risks of policy non-compliance, unauthorized promotion, or control bypass.
+
+### Security Risk
+
+Risks related to identity compromise, integrity failure, unauthorized access, or replay/tamper behavior.
+
+### Knowledge Risk
+
+Risks from incorrect, stale, contradictory, or low-evidence knowledge artifacts.
+
+### Execution Risk
+
+Risks caused by unsafe or mis-scoped action execution in CATS workflows.
+
+### Creative Risk
+
+Risks from speculative outputs (dream/creative hypotheses) that may be novel but unsafe or unverified.
+
+## 3. Risk Scoring
+
+Risk scoring uses four dimensions:
+
+- `impact`: expected consequence severity if risk materializes;
+- `likelihood`: estimated probability of occurrence;
+- `governance_sensitivity`: policy/compliance criticality of affected scope;
+- `system_exposure`: breadth of affected tenants, workflows, and dependencies.
+
+Scoring rules:
+
+- each dimension is normalized to a policy-defined scale;
+- composite risk score is computed with versioned weighting;
+- high governance sensitivity can elevate risk tier even when likelihood is moderate.
+
+## 4. Risk Detection Sources
+
+Risk detection signals originate from:
+
+- Cognitive Heatmap;
+- Dream Engine insights;
+- execution failures;
+- governance signals.
+
+Detection requirements:
+
+- all signals must be lineage-linked and scope-validated;
+- cross-source correlation is required for high/critical classification.
+
+Anomaly-to-risk handoff rules:
+
+- Cognitive Heatmap detects anomalies and concentration patterns.
+- Risk Management evaluates whether a detected anomaly constitutes a classified risk event.
+- Heatmap does not directly classify final risk severity without Risk Management evaluation.
+
+Neutral external actor classification rule:
+
+- external actors, systems, or non-users must not be classified as hostile or adversarial by default;
+- default classification is `neutral` unless explicit evidence, governance determination, or policy rules justify higher-risk classification.
+
+Operational effects:
+
+- risk classification starts from neutral baseline for external actors;
+- lifecycle-affecting risk actions require evidence-backed escalation path;
+- context-aware reasoning must avoid speculative hostility assumptions.
+
+## 5. Risk Mitigation Actions
+
+Primary mitigation actions:
+
+- quarantine ideas;
+- require consortium review;
+- limit execution permissions;
+- increase governance scrutiny.
+
+Action rules:
+
+- mitigation must be proportional to risk tier;
+- critical-path safety controls take priority over optimization goals;
+- mitigations must emit traceable reason-coded events.
+
+## 6. Risk Escalation
+
+Risk levels:
+
+- low
+- moderate
+- high
+- critical
+
+Escalation rules:
+
+- **low:** monitor and trend; no immediate hard control required.
+- **moderate:** apply bounded mitigation and schedule consortium/governance review.
+- **high:** enforce immediate control actions (permission limits/quarantine) and trigger expedited review.
+- **critical:** enforce emergency containment, block unsafe pathways, and trigger governance incident protocol.
+
+Additional escalation controls:
+
+- repeated moderate risks in same domain may auto-escalate to high;
+- unresolved high risk past SLA window auto-escalates to critical review path.
+
+## 7. Risk Ledger
+
+All identified risks must be recorded in an immutable Risk Ledger for audit and replay analysis.
+
+Ledger requirements:
+
+- append-only risk events with timestamps and actor/system identity;
+- risk category, score components, tier, and mitigation actions captured;
+- escalation history and resolution status linked to lineage IDs;
+- retention and access governed by policy and compliance class.
+
+### Canonical Risk Ledger Schema (JSON)
+
+```json
+{
+  "risk_event_id": "risk_0001",
+  "entity_type": "learner | agent | CATS | router | policy | memory",
+  "entity_id": "string",
+  "risk_category": "operational | governance | security | knowledge | execution | creative",
+  "risk_score": 0.0,
+  "impact": 0.0,
+  "likelihood": 0.0,
+  "detected_by": "heatmap | governance | stability | external_signal",
+  "mitigation_action": "monitor | quarantine | throttle | escalate | restrict",
+  "status": "open | mitigated | escalated | closed",
+  "timestamp": "utc",
+  "schema_version": "1.0"
+}
+```
+
+Schema and audit contract:
+
+- `schema_version` is mandatory and follows semantic compatibility policy;
+- risk entries must be immutable or strictly versioned;
+- all risk ledger writes must remain auditable and lineage-linked.
+
+## 8. Operational SLO Targets
+
+- risk detection latency target: <= 10 seconds from source signal ingestion;
+- risk classification latency target: <= 30 seconds from detection;
+- escalation initiation latency target: <= 15 seconds after high/critical classification.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    CH[Cognitive Heatmap] --> RD[Risk Detection]
+    DE[Dream Engine Insights] --> RD
+    EF[Execution Failures] --> RD
+    GS[Governance Signals] --> RD
+    RD --> RS[Risk Scoring]
+    RS --> RT[Risk Tiering]
+    RT --> MA[Mitigation Actions]
+    RT --> RE[Escalation Engine]
+    MA --> RL[Risk Ledger]
+    RE --> RL
+```
+
+## Enforcement Statement
+
+No risk event is considered managed unless it is scored, mitigated or escalated by policy, and recorded in the Risk Ledger with auditable lineage.
+
+## Related Specifications
+
+- [CM-33 Cognitive Heatmap System](./CM-33-cognitive-heatmap-system.md)
+- [CM-37 Cognitive Stability System](./CM-37-cognitive-stability-system.md)
+- [CM-38 Repair Agents and Recovery Clinics](./CM-38-repair-agents-and-recovery-clinics.md)
+- [CM-40 Cognitive Life Cycle Management](./CM-40-cognitive-life-cycle-management.md)

--- a/docs/architecture/cognitive-mesh/CM-35-creative-project-management.md
+++ b/docs/architecture/cognitive-mesh/CM-35-creative-project-management.md
@@ -1,0 +1,120 @@
+# RocketGPT Creative Project Management Framework
+
+**Document ID:** CM-35  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose
+
+Creative exploration must be structured and governed to convert speculative ideas into measurable, safe, and auditable outcomes. In a cognitive system, unmanaged creativity can produce uncontrolled execution risk, policy drift, and low-quality experimentation.
+
+This framework ensures:
+
+- creative work is aligned to explicit objectives and evaluation criteria;
+- exploration remains bounded by governance and risk controls;
+- outcomes and failures are captured for system learning and memory.
+
+## 2. Idea Lifecycle
+
+Canonical lifecycle:
+
+`dream insight -> topic proposal -> exploration project -> consortium review -> execution -> learning`
+
+Lifecycle rules:
+
+- dream insights are non-authoritative until reviewed;
+- project initiation requires scope, risk class, and success criteria;
+- execution must be policy-authorized and trace-linked;
+- all lifecycle transitions must emit auditable events.
+
+## 3. Creative Project Types
+
+### Exploratory
+
+Investigates new hypotheses where uncertainty is high and evidence is limited.
+
+### Experimental
+
+Tests defined assumptions in controlled conditions with measurable outcomes.
+
+### Optimization
+
+Improves existing workflows, strategies, or performance baselines.
+
+### Strategic
+
+Targets long-horizon capability shifts, architectural direction, or major policy-aligned transformation.
+
+## 4. Project Governance
+
+Every creative exploration project must define:
+
+- `objective`
+- `risk_level`
+- `expected_impact`
+- `evaluation_metrics`
+
+Governance requirements:
+
+- risk-level-appropriate review path (including consortium when required);
+- explicit execution permissions and policy scope;
+- clear stop conditions for unsafe or non-performing projects.
+
+Risk gate contract:
+
+- no creative project may transition from exploration or proposal state into execution or rollout state without formal risk classification under CM-34 and required governance review where applicable.
+- dream-derived ideas must follow Dream Engine review and proposal controls before project execution.
+- creative projects that affect active entities must pass lifecycle and governance transition checks.
+
+## 5. Project Tracking
+
+Each project must track:
+
+- progress
+- outcomes
+- failures
+- lessons learned
+
+Tracking requirements:
+
+- milestones and status updates are timestamped and lineage-linked;
+- outcome metrics are compared against declared evaluation metrics;
+- failures and lessons feed Learning Output and Memory Fabric updates.
+
+## 6. Project Completion
+
+A project must end with one completion state:
+
+- success
+- failure
+- partial success
+- deferred outcome
+
+Completion controls:
+
+- final state requires rationale and evidence summary;
+- deferred outcomes must define explicit re-entry criteria;
+- completion artifacts are stored for replay, audit, and future project selection.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    DI[Dream Insight] --> TP[Topic Proposal]
+    TP --> EP[Exploration Project]
+    EP --> CR[Consortium Review]
+    CR --> EX[Execution]
+    EX --> LR[Learning]
+    LR --> MF[Memory Fabric]
+```
+
+## Enforcement Statement
+
+Creative initiatives are valid only when governed as structured projects with explicit objectives, risk controls, measurable outcomes, and auditable completion states.
+
+## Related Specifications
+
+- [CM-27 Dream Engine Architecture](./CM-27-dream-engine-architecture.md)
+- [CM-34 Risk Management and Mitigation Framework](./CM-34-risk-management-framework.md)
+- [CM-40 Cognitive Life Cycle Management](./CM-40-cognitive-life-cycle-management.md)

--- a/docs/architecture/cognitive-mesh/CM-36-existence-context-awareness.md
+++ b/docs/architecture/cognitive-mesh/CM-36-existence-context-awareness.md
@@ -1,0 +1,120 @@
+# RocketGPT Existence and Context Awareness Model
+
+**Document ID:** CM-36  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose
+
+Intelligent systems require contextual awareness to reason safely, act effectively, and remain aligned with user goals and governance boundaries. Without awareness of self-state, user context, and external environment, reasoning quality degrades and risk increases.
+
+This model defines how RocketGPT maintains grounded awareness during cognitive and execution workflows.
+
+## 2. Awareness Layers
+
+RocketGPT awareness is organized into three layers:
+
+- System Awareness
+- User Awareness
+- External World Awareness
+
+Each layer contributes structured context used by planning, routing, execution, and governance decisions.
+
+## 3. System Awareness
+
+RocketGPT must maintain active awareness of:
+
+- its capabilities
+- its limitations
+- its current tasks
+- its operational health
+
+System-awareness requirements:
+
+- capabilities and limits must be explicit and queryable;
+- active task state must remain trace-linked to execution context;
+- health signals must influence planning confidence and fallback behavior.
+
+## 4. User Awareness
+
+RocketGPT must understand:
+
+- who the user is
+- user intent
+- user goals
+- user constraints
+
+User-awareness requirements:
+
+- identity and authorization scope must be validated;
+- intent and goals must be inferred with evidence and updated as context changes;
+- constraints (time, policy, safety, domain limits) must be preserved across the reasoning chain.
+
+## 5. External Awareness
+
+RocketGPT must recognize that:
+
+- many actors exist outside the system
+- non-users are not adversaries
+- external systems may interact with RocketGPT
+
+External-awareness requirements:
+
+- external entities are modeled neutrally unless risk evidence indicates otherwise;
+- interaction assumptions must be evidence-driven, not speculative hostility;
+- integrations with external systems must follow Zero-Trust and governance policies.
+
+Neutral external actor operational rule:
+
+- external actors, systems, or non-users must not be classified as hostile or adversarial by default;
+- default classification is `neutral` unless explicit evidence, governance determination, or policy rules justify higher-risk classification.
+
+Operational effects:
+
+- risk classification begins from neutral baseline and must be evidence-raised;
+- lifecycle decisions must not impose restriction/retirement solely from unverified external assumptions;
+- context-aware reasoning must preserve neutral treatment until validated contrary evidence exists.
+
+## 6. Ethical Awareness
+
+RocketGPT must avoid harmful reasoning about external actors.
+
+Ethical-awareness rules:
+
+- no adversarial framing without validated risk evidence;
+- avoid bias, dehumanization, or unjustified threat assumptions;
+- apply proportional, policy-bound reasoning in risk classification and response;
+- escalate ambiguous high-impact ethical cases to governance review.
+
+## 7. Context Memory
+
+Awareness context must be persisted in Context Memory so downstream reasoning remains grounded and consistent over time.
+
+Context-memory requirements:
+
+- store structured awareness snapshots with lineage and timestamps;
+- preserve tenant/user/task boundaries and retention policies;
+- make context retrievable for planning, consortium review, and audit replay;
+- update context as state changes while retaining prior snapshots for explainability.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    SA[System Awareness] --> CM[Context Memory]
+    UA[User Awareness] --> CM
+    EA[External World Awareness] --> CM
+    CM --> RP[Reasoning Planner]
+    CM --> MR[Mesh Router]
+    CM --> GOV[Governance]
+```
+
+## Enforcement Statement
+
+RocketGPT reasoning and execution are valid only when grounded in current System, User, and External awareness context and constrained by ethical and governance rules.
+
+## Related Specifications
+
+- [CM-34 Risk Management and Mitigation Framework](./CM-34-risk-management-framework.md)
+- [CM-40 Cognitive Life Cycle Management](./CM-40-cognitive-life-cycle-management.md)

--- a/docs/architecture/cognitive-mesh/CM-37-cognitive-stability-system.md
+++ b/docs/architecture/cognitive-mesh/CM-37-cognitive-stability-system.md
@@ -1,0 +1,235 @@
+# RocketGPT Cognitive Stability System
+
+**Document ID:** CM-37  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose
+
+A governed intelligence system requires a dedicated stability layer to keep adaptation safe, bounded, and recoverable under changing conditions. The Cognitive Stability System prevents local instability from propagating into system-wide degradation.
+
+The stability layer must prevent:
+
+- runaway creativity
+- reasoning loops
+- degraded learners
+- unstable routing
+- repeated failed execution
+- governance overload
+- systemic collapse after major changes
+
+## 2. Stability Domains
+
+### Learner Stability
+
+Tracks learner quality drift, volatility, and persistent underperformance.
+
+### Agent Stability
+
+Tracks expert/agent behavioral consistency, loop tendencies, and policy adherence.
+
+### CATS Stability
+
+Tracks CATS execution reliability, rollback pressure, and workflow health.
+
+### Routing Stability
+
+Tracks route oscillation, failover churn, and queue instability.
+
+### Memory Stability
+
+Tracks contradiction density, stale pattern accumulation, and memory coherence.
+
+### Governance Stability
+
+Tracks policy gate pressure, rejection surges, and control-path saturation.
+
+### Consortium Stability
+
+Tracks deadlock frequency, escalation pressure, and decision throughput health.
+
+## 3. Stability Signals
+
+Required measurable signals:
+
+- repeated failure rate
+- contradiction rate
+- degraded success rate
+- governance rejection surge
+- risk escalation frequency
+- execution rollback frequency
+- stale reasoning patterns
+- instability clusters from Cognitive Heatmap
+
+Signal rules:
+
+- all signals must be lineage-linked and time-windowed;
+- signal thresholds are domain-specific and policy-versioned;
+- correlated multi-domain spikes increase instability severity tier.
+
+## 4. Stability States
+
+State model:
+
+- healthy
+- watch
+- degraded
+- critical
+- isolated
+
+Transition rules:
+
+- `healthy -> watch`: early warning threshold exceeded in one or more domains.
+- `watch -> degraded`: sustained threshold breach or multi-signal correlation.
+- `degraded -> critical`: high-severity breach, repeated rollback, or governance overload.
+- `critical -> isolated`: containment required to prevent propagation.
+- recovery transitions require verified stabilization over policy-defined windows.
+
+## 5. Stability Actions
+
+The system applies one or more actions by state and domain:
+
+- monitor
+- throttle
+- quarantine
+- reroute
+- repair
+- rehabilitate
+- upgrade
+- escalate
+
+Action behavior:
+
+- `monitor`: enhanced telemetry and trend verification.
+- `throttle`: reduce unstable throughput and adaptation velocity.
+- `quarantine`: isolate unsafe learners/agents/memory branches.
+- `reroute`: shift traffic away from unstable paths.
+- `repair`: invoke corrective workflows and replay-safe fixes.
+- `rehabilitate`: controlled re-entry with stricter gates.
+- `upgrade`: apply vetted corrective package or policy update.
+- `escalate`: trigger consortium/governance/risk incident path.
+
+## 6. Integration
+
+### Cognitive Heatmap
+
+Provides instability clusters, trend acceleration, and hotspot localization.
+
+### Risk Management Framework
+
+Consumes and contributes risk-tier signals for mitigation and escalation alignment.
+
+### Dream Engine
+
+Receives stability constraints; dream outputs are throttled/quarantined during unstable states.
+
+### Learner Reputation Engine
+
+Uses stability signals to apply trust/rating caution bands and candidate gating.
+
+### Repair Agents
+
+Execute bounded remediation plans for degraded and critical states.
+
+### Governance Layer
+
+Authoritative controller for high-impact containment, escalation, and re-entry approval.
+
+## Controller Precedence Matrix
+
+| Condition | Primary Controller | Secondary Controller |
+|---|---|---|
+| Risk detected | Risk Management | Cognitive Stability |
+| System degradation detected | Cognitive Stability | Repair Agents / Recovery Clinics |
+| Component failure | Repair Agents / Recovery Clinics | Cognitive Stability |
+| Policy violation | Governance | Risk Management |
+| Entity lifecycle transition | Cognitive Life Cycle Management | Cognitive Stability |
+
+Precedence contract:
+
+- Risk Management classifies and mitigates risk.
+- Cognitive Stability detects degradation and instability.
+- Repair Agents / Recovery Clinics perform repair and recovery.
+- Cognitive Life Cycle Management governs entity-state transitions.
+- Governance remains authoritative for policy violations and rule enforcement.
+
+## Trigger Ownership and Handoff Contract
+
+Ownership rules:
+
+- Cognitive Stability detects degradation or instability.
+- Repair Agents / Recovery Clinics execute diagnosis, repair, retraining, or replacement.
+- Cognitive Life Cycle Management updates lifecycle state transitions such as `degraded`, `under_repair`, `rehabilitated`, `restricted`, `retired`.
+
+Handoff flow:
+
+`stability detection -> repair trigger -> repair execution -> validation -> lifecycle state update -> monitored reintegration`
+
+## 7. Stability Ledger
+
+All major stability events must be logged in an immutable Stability Ledger for audit and learning.
+
+Ledger requirements:
+
+- record state transitions, triggers, and applied actions;
+- include actor/system identity, timestamps, and reason codes;
+- preserve lineage links to signals, packets, decisions, and outcomes;
+- support deterministic replay for post-incident analysis and policy tuning.
+
+### Canonical Stability Ledger Schema (JSON)
+
+```json
+{
+  "stability_event_id": "stab_001",
+  "entity_type": "learner | agent | CATS | router | memory_pattern",
+  "entity_id": "string",
+  "stability_state": "healthy | watch | degraded | critical | isolated",
+  "trigger_signal": "failure_rate | contradiction_burst | rollback_spike | stale_pattern | instability_cluster",
+  "detected_by": "stability_monitor",
+  "action_taken": "monitor | throttle | isolate | repair | escalate",
+  "timestamp": "utc",
+  "schema_version": "1.0"
+}
+```
+
+Event contract:
+
+- stability events must be immutable or strictly versioned;
+- `schema_version` is mandatory for compatibility management;
+- relevant records must link to Risk Ledger and Lifecycle Ledger event references.
+
+## 8. Stability and Recovery SLO Targets
+
+- anomaly detection latency: < 10 seconds;
+- component isolation latency: < 5 seconds;
+- repair initiation latency: < 30 seconds;
+- recovery time objective: < 5 minutes for recoverable classes.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    SIG[Stability Signals] --> ENG[Stability State Engine]
+    ENG --> ACT[Stability Actions]
+    ACT --> INT[Integrated Subsystems]
+    INT --> HEAT[Cognitive Heatmap]
+    INT --> RISK[Risk Management]
+    INT --> DREAM[Dream Engine]
+    INT --> REP[Learner Reputation Engine]
+    INT --> REPAIR[Repair Agents]
+    INT --> GOV[Governance Layer]
+    ENG --> LED[Stability Ledger]
+    ACT --> LED
+```
+
+## Enforcement Statement
+
+No sustained instability condition is considered resolved until state recovery is verified by policy, integrated controls are reconciled, and all major events are recorded in the Stability Ledger.
+
+## Related Specifications
+
+- [CM-34 Risk Management and Mitigation Framework](./CM-34-risk-management-framework.md)
+- [CM-38 Repair Agents and Recovery Clinics](./CM-38-repair-agents-and-recovery-clinics.md)
+- [CM-39 Adaptive Upgrade and Rehabilitation Framework](./CM-39-adaptive-upgrade-and-rehabilitation.md)
+- [CM-40 Cognitive Life Cycle Management](./CM-40-cognitive-life-cycle-management.md)

--- a/docs/architecture/cognitive-mesh/CM-38-repair-agents-and-recovery-clinics.md
+++ b/docs/architecture/cognitive-mesh/CM-38-repair-agents-and-recovery-clinics.md
@@ -1,0 +1,200 @@
+# RocketGPT Repair Agents and Recovery Clinics
+
+**Document ID:** CM-38  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose
+
+RocketGPT requires a dedicated repair ecosystem to prevent persistent degradation, cascading instability, and systemic collapse. Repair Agents and Recovery Clinics provide controlled diagnosis, intervention, and recovery pathways for degraded intelligence and execution components.
+
+The repair ecosystem ensures:
+
+- rapid containment of unstable components;
+- structured remediation proportional to issue severity;
+- governed recovery with auditable validation and monitored re-entry.
+
+## 2. Repair Scope
+
+Repair entities include:
+
+- learners
+- reasoning agents
+- consortium support agents
+- CATS workflows
+- routing components
+- memory indexes
+- governance adapters
+
+Scope rule:
+
+- repair actions are entity-specific but coordinated through shared safety and governance controls.
+
+## 3. Repair Layers
+
+### Emergency Response Unit
+
+Immediate stabilization layer for active incidents and critical degradation.
+
+- purpose: stop propagation and preserve safety;
+- actions: isolate, throttle, reroute, emergency containment.
+
+### Clinic
+
+Minor diagnosis and corrective fix layer.
+
+- purpose: resolve localized defects with minimal disruption;
+- actions: targeted patching, parameter correction, limited replay validation.
+
+### Hospital
+
+Deep repair and major intervention layer.
+
+- purpose: address severe or structural failures;
+- actions: full subsystem repair, replacement, deep forensic analysis, controlled rollback.
+
+### Rehabilitation Center
+
+Retraining and monitored re-entry layer.
+
+- purpose: recondition repaired entities before full production return;
+- actions: retraining, sandbox trials, graduated traffic exposure, stability observation.
+
+## 4. Repair Agent Roles
+
+### Diagnostic Agent
+
+Performs fault isolation, root-cause analysis, and severity classification.
+
+### Patch Agent
+
+Applies approved corrective patches and configuration updates.
+
+### Retraining Agent
+
+Rebuilds degraded behavior models or strategies from validated evidence.
+
+### Validation Agent
+
+Executes independent post-repair verification against quality and policy criteria.
+
+### Reintegration Agent
+
+Controls staged production re-entry and post-repair monitoring.
+
+## 5. Repair Triggers
+
+Repair may be triggered by:
+
+- repeated failures
+- degraded Learner Rating
+- failed CAT execution chains
+- governance rejection spikes
+- routing instability
+- contradiction bursts
+- risk management escalation
+- major consortium policy update
+
+Trigger rule:
+
+- high/critical triggers can force immediate Emergency Response Unit activation.
+
+## 6. Repair Workflow
+
+Canonical workflow:
+
+`detect issue -> isolate component if needed -> diagnose cause -> choose repair path -> patch / retrain / replace -> validate -> reintegrate -> monitor post-recovery`
+
+Workflow controls:
+
+- every transition requires identity, timestamp, and reason code;
+- severity determines layer selection (Clinic/Hospital/Rehabilitation);
+- unresolved validation automatically returns entity to isolation or deeper repair layer.
+
+Trigger ownership and handoff contract:
+
+- Cognitive Stability detects degradation or instability.
+- Repair Agents / Recovery Clinics execute diagnosis, repair, retraining, or replacement.
+- Cognitive Life Cycle Management updates lifecycle state transitions such as `degraded`, `under_repair`, `rehabilitated`, `restricted`, `retired`.
+
+Handoff flow:
+
+`stability detection -> repair trigger -> repair execution -> validation -> lifecycle state update -> monitored reintegration`
+
+## 7. Repair Safety Rules
+
+- repair actions must not bypass governance;
+- repair agents must not self-certify recovery;
+- all repaired entities require independent validation before reintegration.
+
+Additional constraints:
+
+- repair actions must preserve lineage and auditability;
+- emergency actions are temporary unless governance-approved as permanent changes.
+
+## 8. Repair Registry
+
+A Repair Registry must maintain, at minimum:
+
+- repaired entity
+- issue type
+- repair method
+- validation result
+- post-repair monitoring period
+
+Registry requirements:
+
+- append-only records for each repair cycle;
+- linkage to triggering signals, risk events, and governance decisions;
+- retention aligned with audit and incident forensics policy.
+
+### Canonical Repair Registry Schema (JSON)
+
+```json
+{
+  "repair_id": "rep_123",
+  "entity_type": "learner | agent | CATS | routing_component | memory_index",
+  "entity_id": "string",
+  "issue_type": "performance_degradation | policy_misalignment | execution_failure | contradiction_instability",
+  "repair_method": "patch | retraining | replacement | rollback | rehabilitation",
+  "validation_status": "pending | passed | failed",
+  "rehabilitation_state": "diagnosed | under_treatment | validating | probation | reintegrated | failed",
+  "post_repair_monitoring_period": "72h",
+  "repair_timestamp": "utc",
+  "schema_version": "1.0"
+}
+```
+
+Schema and validation contract:
+
+- `schema_version` is mandatory and must follow compatibility policy;
+- no repaired entity may self-certify recovery;
+- validation must be external to repair execution.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    TRIG[Repair Triggers] --> ERU[Emergency Response Unit]
+    ERU --> CL[Clinic]
+    CL --> H[Hospital]
+    H --> RH[Rehabilitation Center]
+    RH --> RI[Reintegration]
+    RI --> MON[Post-Recovery Monitoring]
+    MON --> REG[Repair Registry]
+    ERU --> REG
+    CL --> REG
+    H --> REG
+    RH --> REG
+```
+
+## Enforcement Statement
+
+No repaired entity is considered production-ready until independent validation passes, governance constraints are satisfied, and recovery evidence is recorded in the Repair Registry.
+
+## Related Specifications
+
+- [CM-37 Cognitive Stability System](./CM-37-cognitive-stability-system.md)
+- [CM-39 Adaptive Upgrade and Rehabilitation Framework](./CM-39-adaptive-upgrade-and-rehabilitation.md)
+- [CM-40 Cognitive Life Cycle Management](./CM-40-cognitive-life-cycle-management.md)

--- a/docs/architecture/cognitive-mesh/CM-39-adaptive-upgrade-and-rehabilitation.md
+++ b/docs/architecture/cognitive-mesh/CM-39-adaptive-upgrade-and-rehabilitation.md
@@ -1,0 +1,139 @@
+# RocketGPT Adaptive Upgrade and Rehabilitation Framework
+
+**Document ID:** CM-39  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose
+
+RocketGPT requires structured upgrade and rehabilitation to prevent unsafe drift, regression, and governance violations caused by ad hoc changes. Controlled pathways ensure that improvements are validated, reversible, and auditable before full production adoption.
+
+## 2. Upgrade Sources
+
+Upgrades may originate from:
+
+- consortium decisions
+- governance rule changes
+- result-based memory
+- dream insights validated by review
+- repeated CATS performance evidence
+- stability system recommendations
+
+All upgrade proposals must include lineage and evidence references.
+
+## 3. Upgrade Targets
+
+Upgrade and rehabilitation targets:
+
+- learners
+- reasoning agents
+- CATS
+- routing policies
+- memory retrieval strategies
+- governance adapters
+
+## 4. Rehabilitation Types
+
+- skill rehabilitation
+- policy rehabilitation
+- routing rehabilitation
+- execution rehabilitation
+- Learner Reputation Rehabilitation
+
+Type selection is determined by root-cause diagnosis, risk class, and governance policy.
+
+Terminology mapping note:
+
+- Learner Rating is the external evidence-driven score.
+- Learner Reputation is the aggregated historical profile.
+- "Trust" must not be used as a synonym unless explicitly mapped to Learner Reputation.
+
+## 5. Upgrade Lifecycle
+
+Canonical lifecycle:
+
+`proposal -> approval -> staged rollout -> validation -> monitored operation -> full adoption or rollback`
+
+Lifecycle rules:
+
+- approval requires governance-aligned evidence and scope authorization;
+- staged rollout is mandatory for non-trivial changes;
+- validation must be independent and policy-bound;
+- rollback remains available until full adoption criteria are met.
+
+## 6. Safe Reintegration
+
+Rehabilitated components re-enter through controlled gates:
+
+- probation period
+- restricted scope
+- increased monitoring
+- outcome-based validation
+
+Reintegration controls:
+
+- no unrestricted re-entry before probation completion;
+- repeated regressions during probation trigger rollback or deeper repair;
+- critical components require explicit governance re-entry approval.
+
+## 7. Versioning and Compatibility
+
+Every rehabilitation or upgrade must maintain:
+
+- version history
+- compatibility record
+- rollback path
+
+Versioning requirements:
+
+- each release artifact has immutable version identifiers;
+- compatibility matrix captures upstream/downstream dependencies;
+- rollback artifacts must be tested and immediately deployable.
+
+## 8. Upgrade and Reintegration SLO Targets
+
+- validation gate completion target: <= 10 minutes for standard upgrade classes;
+- rollback trigger latency: <= 30 seconds after rollback condition match;
+- rollback completion target: <= 3 minutes for reversible rollout classes;
+- probation monitoring window: minimum 72 hours before unrestricted adoption.
+
+## 9. Learning Feedback
+
+Rehabilitation outcomes must feed back into:
+
+- Result-Based Memory
+- Cognitive Memory
+- Governance Memory
+- Repair Registry
+
+Feedback rules:
+
+- all outcomes (success, partial, failure) are recorded with evidence;
+- feedback updates future upgrade prioritization and stability policy thresholds.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    SRC[Upgrade Sources] --> PROP[Proposal]
+    PROP --> APPR[Approval]
+    APPR --> STAGE[Staged Rollout]
+    STAGE --> VAL[Validation]
+    VAL --> MON[Monitored Operation]
+    MON --> ADOPT[Full Adoption]
+    MON --> RB[Rollback]
+    ADOPT --> FB[Learning Feedback]
+    RB --> FB
+    FB --> MEM[Result/Cognitive/Governance Memory]
+    FB --> REG[Repair Registry]
+```
+
+## Enforcement Statement
+
+No upgrade or rehabilitation is production-authoritative without governed approval, validated compatibility, monitored reintegration, and auditable feedback registration.
+
+## Related Specifications
+
+- [CM-38 Repair Agents and Recovery Clinics](./CM-38-repair-agents-and-recovery-clinics.md)
+- [CM-40 Cognitive Life Cycle Management](./CM-40-cognitive-life-cycle-management.md)

--- a/docs/architecture/cognitive-mesh/CM-40-cognitive-life-cycle-management.md
+++ b/docs/architecture/cognitive-mesh/CM-40-cognitive-life-cycle-management.md
@@ -1,0 +1,264 @@
+# RocketGPT Cognitive Life Cycle Management
+
+**Document ID:** CM-40  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose
+
+RocketGPT must operate as a continuously renewing cognitive ecosystem, not a static intelligence system. Lifecycle governance is required to keep intelligence aligned, current, safe, and resilient under changing evidence, policy, and environment conditions.
+
+The lifecycle system must prevent:
+
+- staleness
+- existential drift
+- outdated assumptions
+- degraded intelligence
+- stale creativity
+- governance blindness
+- long-term system brittleness
+
+## 2. Managed Entity Types
+
+Lifecycle management applies to:
+
+- learners
+- reasoning agents
+- consortium support agents
+- CATS workflows
+- repair agents
+- memory patterns
+- routing policies
+- governance adapters
+
+## 3. Lifecycle Stages
+
+Canonical states:
+
+`proposed -> incubating -> trained -> validated -> active -> monitored -> degraded -> under_repair -> rehabilitated -> restricted -> retired -> archived`
+
+Usage model:
+
+- not all entity types require every stage;
+- stage subsets are policy-defined per entity class;
+- transitions require identity, reason code, and governance scope checks.
+
+## 4. Entry and Incubation
+
+New entities are introduced with explicit controls:
+
+- source of creation
+- scope of operation
+- probationary period
+- validation requirements
+- risk classification
+- monitoring requirements
+
+Entry rules:
+
+- no entity may skip validation gates into active duty;
+- probation scope must be bounded by tenant/workflow/policy constraints.
+
+## 5. Active Duty and Monitoring
+
+Active entities must be continuously monitored for:
+
+- performance
+- governance compliance
+- relevance
+- stability
+- compatibility
+- external fitness
+
+Monitoring behavior:
+
+- thresholds are entity-specific and policy-versioned;
+- sustained adverse trends trigger degradation workflows.
+
+## 6. Degradation Detection
+
+Degradation signals include:
+
+- declining outcomes
+- contradiction bursts
+- repeated governance rejection
+- lower relevance
+- stale behavior patterns
+- increased repair events
+- rising instability
+
+Detection rules:
+
+- multi-signal correlation raises severity;
+- high/critical degradation can force immediate restriction or isolation.
+
+## 7. Repair and Rehabilitation
+
+Degraded entities move through repair, rehabilitation, validation, and controlled re-entry.
+
+Process alignment:
+
+- stability classification and action selection from CM-37;
+- repair layer execution and registry requirements from CM-38;
+- upgrade/reintegration lifecycle and rollback controls from CM-39.
+
+References:
+
+- [CM-37 Cognitive Stability System](./CM-37-cognitive-stability-system.md)
+- [CM-38 Repair Agents and Recovery Clinics](./CM-38-repair-agents-and-recovery-clinics.md)
+- [CM-39 Adaptive Upgrade and Rehabilitation Framework](./CM-39-adaptive-upgrade-and-rehabilitation.md)
+
+## 8. Retirement and Archival
+
+Entities are retired when no longer fit, relevant, or policy-eligible for active use.
+
+Retirement and archival rules:
+
+- retirement must preserve final state rationale and lineage references;
+- archived entities remain queryable for audit, replay, and future learning;
+- reactivation requires explicit revalidation and governance approval.
+
+## 9. Lineage and Succession
+
+The lifecycle system tracks:
+
+- which entity replaced another
+- version evolution
+- rehabilitation lineage
+- superseded policies or workflows
+- inherited knowledge paths
+
+Lineage requirements:
+
+- succession links must be immutable and timestamped;
+- inheritance paths must preserve evidence and compatibility context.
+
+## 10. Existential Awareness Checkpoints
+
+Periodic checkpoints must evaluate:
+
+- whether assumptions remain valid
+- whether objectives are still aligned
+- whether external conditions have shifted
+- whether the system is becoming closed-loop or stale
+- whether non-users or external actors are being treated neutrally and correctly rather than as automatic threats
+
+Checkpoint outcomes must drive lifecycle actions (continue, restrict, rehabilitate, retire).
+
+## 11. Context and Ethical Awareness
+
+Lifecycle governance enforces ongoing awareness that:
+
+- the system must remain aware of its own existence, limits, and current health
+- the system must remain aware of the user's existence, intent, and goals
+- the system must recognize that many actors outside the platform exist and are not enemies by default
+
+These requirements are mandatory for safe reasoning, renewal, and external interaction posture.
+
+## 12. Lifecycle Ledger
+
+All major lifecycle transitions must be recorded in an auditable Lifecycle Ledger.
+
+Ledger requirements:
+
+- append-only transition records;
+- entity ID, prior/new state, actor/system identity, reason code, timestamp;
+- lineage links to risk, repair, governance, and outcome artifacts;
+- retention and replay support for audits and long-horizon learning.
+
+## 13. Lifecycle Ledger Event Taxonomy
+
+Lifecycle event classes:
+
+- `entity_created`
+- `entity_validated`
+- `entity_activated`
+- `entity_monitored`
+- `entity_degraded`
+- `entity_under_repair`
+- `entity_rehabilitated`
+- `entity_restricted`
+- `entity_retired`
+- `entity_archived`
+- `entity_reactivated`
+- `entity_superseded`
+
+Canonical Lifecycle Ledger schema:
+
+```json
+{
+  "lifecycle_event_id": "life_223",
+  "entity_type": "learner | agent | CATS | repair_agent | policy_adapter | memory_pattern",
+  "entity_id": "string",
+  "previous_state": "active",
+  "new_state": "under_repair",
+  "trigger_source": "risk | stability | governance | repair_validation | lifecycle_policy",
+  "decision_reference": "optional_id",
+  "timestamp": "utc",
+  "schema_version": "1.0"
+}
+```
+
+### Mandatory Transition Baselines
+
+| Entity Type | Mandatory Transition Baseline |
+|---|---|
+| learners | `proposed -> incubating -> trained -> validated -> active -> monitored`; degradation path must include `degraded -> under_repair -> rehabilitated/restricted`; retirement path must include `retired -> archived` |
+| reasoning agents | `proposed -> incubating -> validated -> active -> monitored`; degradation path must include `degraded -> under_repair`; reintegration path must include `rehabilitated -> restricted/active` |
+| CATS workflows | `proposed -> incubating -> validated -> active -> monitored`; failure path must include `degraded -> under_repair -> validated`; terminal path must include `retired -> archived` |
+
+## 14. Cross-Document Alignment
+
+This lifecycle framework is aligned with and depends on the following Cognitive Mesh specifications:
+
+- [CM-33 Cognitive Heatmap System](./CM-33-cognitive-heatmap-system.md)  
+  Provides instability, activity, and concentration signals used in lifecycle monitoring and degradation detection.
+- [CM-34 Risk Management and Mitigation Framework](./CM-34-risk-management-framework.md)  
+  Provides risk classification, mitigation, and escalation pathways tied to lifecycle state transitions.
+- [CM-35 Creative Project Management Framework](./CM-35-creative-project-management.md)  
+  Provides governed creative exploration pathways that feed entity incubation, validation, and retirement decisions.
+- [CM-36 Existence and Context Awareness Model](./CM-36-existence-context-awareness.md)  
+  Provides existential, user, and external-awareness checkpoints required for lifecycle alignment and anti-drift controls.
+- [CM-37 Cognitive Stability System](./CM-37-cognitive-stability-system.md)  
+  Provides stability states, signals, and corrective action triggers used in degradation and restriction decisions.
+- [CM-38 Repair Agents and Recovery Clinics](./CM-38-repair-agents-and-recovery-clinics.md)  
+  Provides layered repair execution model for `under_repair` and `rehabilitated` lifecycle stages.
+- [CM-39 Adaptive Upgrade and Rehabilitation Framework](./CM-39-adaptive-upgrade-and-rehabilitation.md)  
+  Provides controlled upgrade, validation, rollback, and safe reintegration contracts for lifecycle renewal.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    P[Proposed] --> I[Incubating]
+    I --> T[Trained]
+    T --> V[Validated]
+    V --> A[Active]
+    A --> M[Monitored]
+    M --> D[Degraded]
+    D --> R[Under Repair]
+    R --> H[Rehabilitated]
+    H --> RS[Restricted]
+    RS --> A
+    RS --> RT[Retired]
+    RT --> AR[Archived]
+    M --> LED[Lifecycle Ledger]
+    D --> LED
+    R --> LED
+    RT --> LED
+```
+
+## Enforcement Statement
+
+No cognitive entity may remain in active duty without lifecycle-state validity, ongoing monitoring, existential/context awareness checks, and auditable transition lineage.
+
+## Related Specifications
+
+- [CM-33 Cognitive Heatmap System](./CM-33-cognitive-heatmap-system.md)
+- [CM-34 Risk Management and Mitigation Framework](./CM-34-risk-management-framework.md)
+- [CM-35 Creative Project Management Framework](./CM-35-creative-project-management.md)
+- [CM-36 Existence and Context Awareness Model](./CM-36-existence-context-awareness.md)
+- [CM-37 Cognitive Stability System](./CM-37-cognitive-stability-system.md)
+- [CM-38 Repair Agents and Recovery Clinics](./CM-38-repair-agents-and-recovery-clinics.md)
+- [CM-39 Adaptive Upgrade and Rehabilitation Framework](./CM-39-adaptive-upgrade-and-rehabilitation.md)

--- a/docs/architecture/cognitive-mesh/CM-41-cognitive-map-and-navigation-system.md
+++ b/docs/architecture/cognitive-mesh/CM-41-cognitive-map-and-navigation-system.md
@@ -1,0 +1,220 @@
+# RocketGPT Cognitive Map and Navigation System
+
+**Document ID:** CM-41  
+**Status:** Production Architecture Specification  
+**Owner:** RocketGPT Architecture  
+**Last Updated:** 2026-03-06
+
+## 1. Purpose
+
+RocketGPT requires a navigation-oriented cognitive map to convert distributed intelligence signals into actionable spatial awareness across the Cognitive Mesh. Logs, ledgers, and memory stores are necessary but insufficient for coordinated prioritization and intervention planning.
+
+The Cognitive Map and Navigation System is required to answer:
+
+- where intelligence activity is concentrated
+- where risk is accumulating
+- where creativity is emerging
+- where degradation is forming
+- where outcomes are strongest
+- where intervention is needed next
+
+This subsystem acts as the navigation cortex for reasoning, routing, consortium focus, repair planning, and lifecycle decisions.
+
+## 2. Core Navigation Domains
+
+The map organizes intelligence across these domains:
+
+- Topic Domain
+- Learner Domain
+- CATS Domain
+- Decision Domain
+- Result Domain
+- Dream Insight Domain
+- Risk Domain
+- Stability Domain
+- Lifecycle Domain
+
+## 3. Map Inputs
+
+Map construction ingests and correlates:
+
+- Knowledge Packets
+- Result Outputs
+- Rating Evidence Events
+- Dream Insights
+- Consortium Decisions
+- Risk Ledger
+- Stability Ledger
+- Repair Registry
+- Lifecycle Ledger
+- Memory Fabric
+- Cognitive Heatmap
+
+Input rules:
+
+- all sources must be lineage-linked and scope-validated;
+- ingestion must enforce Zero-Trust and policy boundaries.
+
+## 4. Map Layers
+
+Conceptual layers:
+
+- Activity Layer
+- Risk Layer
+- Outcome Layer
+- Creativity Layer
+- Stability Layer
+- Lifecycle Layer
+- Relationship Layer
+
+Layer behavior:
+
+- each layer is queryable independently and in cross-layer joins;
+- cross-layer overlays drive prioritization and intervention recommendations.
+
+## 5. Navigation Functions
+
+Core functions:
+
+- locate high-value intelligence zones
+- locate high-risk clusters
+- locate degraded entities
+- locate successful reasoning patterns
+- locate reusable outcomes
+- locate dormant but promising creative ideas
+- locate entities needing repair or retirement
+
+## 6. Navigation Queries
+
+Example queries:
+
+- Which learners are most strongly linked to repeated successful outcomes?
+- Which topics have high creative activity but also high governance risk?
+- Which CATS workflows are producing degraded results and require repair?
+- Which dream insights are closest to becoming validated projects?
+- Which lifecycle clusters are at risk of stagnation?
+
+Query contract:
+
+- query results must include evidence lineage and confidence metadata;
+- cross-tenant data joins are disallowed unless explicitly policy-authorized.
+
+## 7. Navigation Priority Rules
+
+Attention prioritization is computed from weighted factors:
+
+- risk severity
+- outcome value
+- governance importance
+- degradation severity
+- strategic relevance
+- user alignment
+
+Priority behavior:
+
+- high-risk/high-impact intersections are escalated first;
+- user-aligned high-value opportunities are surfaced when risk posture is acceptable;
+- policy-critical items can preempt purely performance-driven opportunities.
+
+## 8. Integration with Existing Systems
+
+### Mesh Router
+
+Consumes map hotspots for route shaping and capacity-aware prioritization.
+
+### Consortium Prioritization
+
+Uses map clusters to select high-value/high-risk review queues.
+
+### Dream Engine
+
+Uses map gaps and emergent creativity zones to target dream-cycle focus.
+
+### Risk Management
+
+Uses map risk clustering to accelerate classification and escalation sequencing.
+
+### Cognitive Stability
+
+Uses degradation geographies and instability propagation paths for containment planning.
+
+### Repair Agents / Recovery Clinics
+
+Uses localized failure and dependency maps to choose repair paths and order of intervention.
+
+### Life Cycle Management
+
+Uses lifecycle concentration maps to trigger revalidation, restriction, retirement, or reactivation decisions.
+
+### Memory Retrieval Engine
+
+Uses navigational relevance context to improve retrieval targeting and enrichment precision.
+
+## 9. Safety and Governance
+
+Safety rules:
+
+- navigation does not override governance;
+- navigation surfaces intelligence, risk, and opportunity;
+- navigation recommendations remain subject to Zero-Trust validation and policy controls.
+
+Control rules:
+
+- no navigation output can directly mutate ratings, EKL state, or governance decisions;
+- all recommendation paths must remain auditable and explainable.
+
+## 10. Metrics
+
+Required metrics:
+
+- `navigation_query_latency`
+- `hotspot_detection_rate`
+- `intervention_recommendation_accuracy`
+- `degradation_localization_accuracy`
+- `creativity_to_project_conversion_visibility`
+
+Metric requirements:
+
+- metrics must be segmentable by tenant/domain/time horizon;
+- metrics must be lineage-correlated for replay and audit.
+
+## 11. Architecture Diagram
+
+```mermaid
+flowchart LR
+    KP[Knowledge Packets] --> MAP[Cognitive Map and Navigation System]
+    RO[Result Outputs] --> MAP
+    REE[Rating Evidence Events] --> MAP
+    DI[Dream Insights] --> MAP
+    CD[Consortium Decisions] --> MAP
+    RL[Risk Ledger] --> MAP
+    SL[Stability Ledger] --> MAP
+    RR[Repair Registry] --> MAP
+    LL[Lifecycle Ledger] --> MAP
+    MF[Memory Fabric] --> MAP
+    CH[Cognitive Heatmap] --> MAP
+
+    MAP --> MR[Mesh Router]
+    MAP --> CONS[Consortium Prioritization]
+    MAP --> RM[Risk Management]
+    MAP --> STAB[Cognitive Stability]
+    MAP --> REPAIR[Repair Agents and Recovery Clinics]
+    MAP --> LCM[Life Cycle Management]
+    MAP --> MRE[Memory Retrieval Engine]
+    MAP --> GOV[Governance]
+```
+
+## 12. Related Specifications
+
+- [CM-28 Memory Fabric Architecture](./CM-28-memory-fabric-architecture.md)
+- [CM-30 Memory Retrieval Engine](./CM-30-memory-retrieval-engine.md)
+- [CM-32 Cognitive Memory Graph](./CM-32-cognitive-memory-graph.md)
+- [CM-33 Cognitive Heatmap System](./CM-33-cognitive-heatmap-system.md)
+- [CM-34 Risk Management and Mitigation Framework](./CM-34-risk-management-framework.md)
+- [CM-37 Cognitive Stability System](./CM-37-cognitive-stability-system.md)
+- [CM-38 Repair Agents and Recovery Clinics](./CM-38-repair-agents-and-recovery-clinics.md)
+- [CM-40 Cognitive Life Cycle Management](./CM-40-cognitive-life-cycle-management.md)
+
+## Enforcement Statement
+
+The Cognitive Map and Navigation System is an intelligence navigation layer only. It must remain governed, Zero-Trust constrained, and auditable, and it may recommend but not directly enforce policy or state mutation actions.

--- a/docs/modules/analyst/ANALYST_LAYER_OVERVIEW.md
+++ b/docs/modules/analyst/ANALYST_LAYER_OVERVIEW.md
@@ -1,0 +1,19 @@
+# Analyst Layer Overview
+
+The Analyst Layer transforms information into decision support.
+
+## Comparative Analysis
+Support comparison across options, states, or scenarios.
+
+## Scenario Analysis
+Enable evaluation of possible futures, risks, and trade-offs.
+
+## Decision Support
+Provide structured outputs that help humans make stronger decisions.
+
+## Output Types
+- Assessments
+- Summaries
+- Comparative matrices
+- Risk views
+- Strategy notes

--- a/docs/modules/cats/CATS_PLATFORM_OVERVIEW.md
+++ b/docs/modules/cats/CATS_PLATFORM_OVERVIEW.md
@@ -1,0 +1,25 @@
+# CATS Platform Overview
+
+CATS stands for Command-Agent-Task System.
+
+## What CATS Means
+A packaging and execution framework for modular, governed AI capabilities.
+
+## Lifecycle of a CAT
+- Define
+- Package
+- Verify
+- Publish
+- Execute
+- Measure
+- Evolve
+- Retire
+
+## Packaging and Versioning
+Each CAT should carry metadata, version identity, capability rules, and operational boundaries.
+
+## Governance Hooks
+CATS must support policy evaluation, audit logging, approvals, and performance history.
+
+## Marketplace and Distribution Direction
+CATS is expected to evolve into a portable, distributable, and monetizable capability ecosystem.

--- a/docs/modules/governance/GOVERNANCE_LAYER_OVERVIEW.md
+++ b/docs/modules/governance/GOVERNANCE_LAYER_OVERVIEW.md
@@ -1,0 +1,18 @@
+# Governance Layer Overview
+
+Governance is the enforcement and trust framework of Mishti AI.
+
+## Policy Gate
+Rules define what can be executed, by whom, under what conditions.
+
+## Compliance Model
+Execution should be measurable against safety, governance, and operational policy.
+
+## Auditability
+Important decisions and actions must be traceable.
+
+## Enforcement Boundaries
+The system should distinguish between allowed, denied, warned, and approval-gated actions.
+
+## Approval and Override Concepts
+Where appropriate, overrides must be explicit, attributable, and logged.

--- a/docs/modules/memory/MEMORY_AND_EXPERIENCE_MODEL.md
+++ b/docs/modules/memory/MEMORY_AND_EXPERIENCE_MODEL.md
@@ -1,0 +1,18 @@
+# Memory and Experience Model
+
+The Memory and Experience Model defines how Mishti AI captures, organizes, and recalls useful experience.
+
+## Experience Capture
+Execution outcomes, contextual signals, and important decisions may form structured experiences.
+
+## Memory Formation
+Experiences can be promoted into reusable memory where policy allows.
+
+## Recall Concepts
+Recall should be relevance-driven, scoped, and governed.
+
+## Learning Boundaries
+The platform must avoid uncontrolled memory growth or unsafe self-modification.
+
+## Governance Around Memory
+Sensitive, policy-restricted, or unverified information must be handled carefully.

--- a/docs/modules/platform-fabric/MISHTI_AI_FABRIC_OVERVIEW.md
+++ b/docs/modules/platform-fabric/MISHTI_AI_FABRIC_OVERVIEW.md
@@ -1,0 +1,18 @@
+# Mishti AI Fabric Overview
+
+The Mishti AI Fabric is the distributed execution and governance substrate of the platform.
+
+## Distributed Node Concept
+Nodes may run on local developer machines, servers, or specialized environments.
+
+## Developer Machine, Server, and Edge Model
+The platform should support single-node development as well as multi-node operation.
+
+## Local vs Central Governance
+Execution may occur locally, but critical policy and reporting can still align with central governance.
+
+## Reporting Back to Central Platform
+Nodes should be able to surface health, events, capability usage, and compliance evidence.
+
+## Future OS Direction
+The long-term direction includes an AI-native operating fabric capable of managing governed intelligent workloads.

--- a/docs/modules/research/RESEARCH_LAYER_OVERVIEW.md
+++ b/docs/modules/research/RESEARCH_LAYER_OVERVIEW.md
@@ -1,0 +1,15 @@
+# Research Layer Overview
+
+The Research Layer supports ingestion, grounding, synthesis, and structured knowledge expansion.
+
+## Ingestion
+The platform can accept documents, references, sources, and external knowledge feeds.
+
+## Synthesis
+Research outputs should combine traceability with clarity.
+
+## Knowledge Expansion
+The layer should progressively enrich understanding while preserving source grounding.
+
+## Grounding and Traceability
+Important claims should remain attributable to evidence wherever possible.

--- a/docs/modules/runtime/COGNITIVE_RUNTIME_OVERVIEW.md
+++ b/docs/modules/runtime/COGNITIVE_RUNTIME_OVERVIEW.md
@@ -1,0 +1,24 @@
+# Cognitive Runtime Overview
+
+The Cognitive Runtime governs execution lifecycle, capability routing, validation, monitoring, and experience capture.
+
+## Execution Lifecycle
+- Intake
+- Validation
+- Dispatch
+- Execution
+- Verification
+- Experience capture
+- Ledger publication
+
+## Runtime and Dispatch Guards
+Guards prevent unsafe routing, invalid execution, and broken policy boundaries.
+
+## Event Flow
+Every significant execution event should be observable and reconstructable.
+
+## Ledgering
+The runtime must record auditable execution artifacts and decision evidence.
+
+## Observability
+Health, behavior, and anomalies should be measurable across local and distributed execution surfaces.

--- a/docs/overview/MISHTI_AI_PLATFORM_OVERVIEW.md
+++ b/docs/overview/MISHTI_AI_PLATFORM_OVERVIEW.md
@@ -1,0 +1,41 @@
+# Mishti AI Platform Overview
+
+Mishti AI is a sovereign AI platform designed to unify intelligent execution, governance, development tooling, memory, research, and operational fabric into one extensible ecosystem.
+
+## Vision
+Mishti AI is intended to evolve beyond a chatbot into a full AI-native platform that can support governed intelligence, modular capability execution, knowledge growth, and developer-centric AI products.
+
+## Core Philosophy
+- Intelligence with governance
+- Experience before blind autonomy
+- Modular capability architecture
+- Provider-agnostic deployment
+- Unified developer and operator workspace
+
+## High-Level Layers
+- Experience Layer
+- Intelligence Layer
+- Research Layer
+- Analyst Layer
+- Execution Layer
+- Governance Layer
+- Platform Fabric
+
+## Major Components
+- Yukti Chat
+- Yukti IDE
+- CATS Platform
+- Cognitive Runtime
+- Governance Engine
+- Memory and Experience Model
+- Research and Analyst Layers
+- Mishti AI Fabric
+
+## Deployment Model
+- Local
+- Enterprise private
+- Hybrid
+- Distributed multi-node
+
+## Summary
+Mishti AI is the parent platform. Yukti Chat is the conversation product. Yukti IDE is the AI-native development product. CATS is the execution ecosystem. Governance and traceability remain central to the platform.

--- a/docs/planner/schemas/planner.v1/README.md
+++ b/docs/planner/schemas/planner.v1/README.md
@@ -1,6 +1,6 @@
 # Planner v1 Output Schema (LOCKED)
 
-This folder defines the canonical output contract for RocketGPT Planner v1.
+This folder defines the canonical output contract for the Mishti AI Planner v1.
 
 ## Artifacts
 - ExecutionPlan.template.json (primary machine contract)

--- a/docs/products/mishti-ai/MISHTI_AI_PRODUCT_BRIEF.md
+++ b/docs/products/mishti-ai/MISHTI_AI_PRODUCT_BRIEF.md
@@ -1,0 +1,28 @@
+# Mishti AI Product Brief
+
+Mishti AI is the core platform brand for the governed AI ecosystem.
+
+## What It Is
+A modular AI platform for orchestration, governance, knowledge growth, and productized intelligent systems.
+
+## Who It Serves
+- Enterprises
+- Product teams
+- Developers
+- AI platform operators
+
+## Value Proposition
+- Unified governed AI platform
+- Modular intelligence execution
+- Extensible product architecture
+- Traceable and auditable operations
+
+## Platform Capabilities
+- Chat and IDE experiences
+- Runtime execution
+- Governance and ledgering
+- Research and analysis layers
+- Distributed AI fabric
+
+## Strategic Direction
+Grow from platform foundation into an extensible AI operating fabric with strong product and ecosystem identity.

--- a/docs/products/yukti-chat/YUKTI_CHAT_PRODUCT_OVERVIEW.md
+++ b/docs/products/yukti-chat/YUKTI_CHAT_PRODUCT_OVERVIEW.md
@@ -1,0 +1,28 @@
+# Yukti Chat Product Overview
+
+Yukti Chat is the conversational product of the Mishti AI platform.
+
+## Purpose
+Provide a governed, context-aware AI interaction layer for users, teams, and workflows.
+
+## User Journeys
+- Ask, explore, decide
+- Execute governed tasks
+- Retrieve knowledge
+- Interact with platform capabilities
+
+## Core Features
+- Conversational interaction
+- Context grounding
+- Knowledge-aware responses
+- Capability invocation
+- Traceable AI activity
+
+## Relation to Mishti AI
+Yukti Chat is the primary human interaction surface on top of the Mishti AI platform.
+
+## Future Scope
+- Team collaboration
+- Meeting and recording intelligence
+- Deep project memory
+- Multi-agent assistance

--- a/docs/products/yukti-ide/YUKTI_IDE_PRODUCT_OVERVIEW.md
+++ b/docs/products/yukti-ide/YUKTI_IDE_PRODUCT_OVERVIEW.md
@@ -1,0 +1,25 @@
+# Yukti IDE Product Overview
+
+Yukti IDE is the AI-native development environment of the Mishti AI platform.
+
+## Purpose
+Provide developers with an integrated workspace for code, chat, knowledge, execution, and AI-assisted development.
+
+## AI-Native IDE Vision
+A development experience where AI is embedded into the full lifecycle: design, coding, debugging, research, docs, governance, and execution.
+
+## Module Responsibilities
+- Code assistance
+- Project context
+- Docs and knowledge
+- Runtime integrations
+- Workflow orchestration
+
+## Relation to Developer Workflow
+Yukti IDE acts as the main creation and execution environment for building on Mishti AI.
+
+## Future Roadmap
+- Deep repo understanding
+- Notebook-style knowledge spaces
+- Integrated recordings and summaries
+- Governed multi-agent development flows

--- a/docs/roadmap/MISHTI_AI_ROADMAP.md
+++ b/docs/roadmap/MISHTI_AI_ROADMAP.md
@@ -1,0 +1,13 @@
+# Mishti AI Roadmap
+
+## Phase 1 - Platform Foundation
+Core runtime, governance, products, docs, and execution model.
+
+## Phase 2 - Agent and CATS Ecosystem
+Portable governed capability bundles, registry, and lifecycle tooling.
+
+## Phase 3 - AI Fabric and OS Direction
+Distributed node architecture, fabric governance, and platform operating model.
+
+## Phase 4 - Advanced Intelligence Collaboration
+Deeper memory, research, analyst layers, and multi-intelligence coordination.

--- a/docs/self_improve/README.md
+++ b/docs/self_improve/README.md
@@ -1,4 +1,4 @@
-# RocketGPT Self-Improve System
+# Mishti AI Self-Improve System
 
 ## Goal
 Detect -> Propose -> Validate -> Execute -> Verify -> PR -> Ledger

--- a/docs/setup/CLI_MIGRATION_GUIDE.md
+++ b/docs/setup/CLI_MIGRATION_GUIDE.md
@@ -1,0 +1,31 @@
+# CLI Migration Guide
+
+## Preferred CLI Prefix
+
+Use `mt` as the preferred CLI prefix for Mishti AI operator and developer workflows.
+
+## Compatibility Policy
+
+Legacy CLI aliases remain available during the controlled migration.
+
+- Preferred entry point: `./scripts/mt.ps1`
+- Preferred health entry point: `./scripts/mt_health.ps1`
+- Legacy compatibility aliases remain supported for existing automation and operator workflows
+
+## Recommended Usage
+
+```powershell
+./scripts/mt.ps1 help
+./scripts/mt.ps1 health
+./scripts/mt.ps1 runs --limit 10
+./scripts/mt.ps1 logs --last-failed
+./scripts/mt.ps1 deploy --wait
+```
+
+Legacy `rgpt` commands are still supported where existing automation, operator habits, or documentation depend on them.
+
+## Migration Notes
+
+- New docs and examples should prefer `mt` where wrapper support exists.
+- Internal technical identifiers such as `RGPT_*`, `src/rgpt`, ledger keys, runtime keys, and compatibility paths remain in place until a later validated phase.
+- This phase changes the operator-facing command surface only. It does not rename package names, import paths, or contract-sensitive identifiers.

--- a/docs/setup/MIGRATION_NOTES_ROCKETGPT_TO_MISHTI_AI.md
+++ b/docs/setup/MIGRATION_NOTES_ROCKETGPT_TO_MISHTI_AI.md
@@ -1,0 +1,22 @@
+# Migration Notes - RocketGPT to Mishti AI
+
+## What Was Renamed
+Repository-facing platform branding has been shifted toward Mishti AI, with Yukti Chat and Yukti IDE introduced as product names.
+
+## Compatibility Considerations
+Some deep technical identifiers may need staged migration to avoid breaking builds, imports, or historical references.
+
+## What Was Intentionally Preserved
+Legacy low-level identifiers may remain temporarily where direct replacement is high risk. This repair pass intentionally leaves the following in place until a controlled compatibility migration is validated:
+
+- `RGPT_*` environment variables and runtime keys
+- `src/rgpt` and other repo-internal technical namespaces
+- legacy governance filenames and historical evidence artifacts
+- repo-local compatibility paths such as `.rocketgpt/*`
+
+## Follow-Up Actions Recommended
+- Review package names
+- Review import paths
+- Review workflow display names
+- Review storage keys and environment variables
+- Complete repo-specific physical renames

--- a/docs/setup/REPOSITORY_STRUCTURE.md
+++ b/docs/setup/REPOSITORY_STRUCTURE.md
@@ -1,0 +1,23 @@
+# Repository Structure
+
+## Top-Level Structure
+- apps: end-user and operator products
+- packages: shared platform modules
+- docs: structured documentation
+- scripts: automation entry points
+- tools: utilities
+- tests: validation assets
+
+## Naming Conventions
+- Platform: Mishti AI
+- Chat product: Yukti Chat
+- IDE product: Yukti IDE
+- CLI prefix: mt
+
+## CLI Entry Points
+- Preferred CLI wrapper: `scripts/mt.ps1`
+- Preferred health wrapper: `scripts/mt_health.ps1`
+- Legacy compatibility aliases remain available during the phased migration
+
+## Developer Guidance
+Keep product concerns, runtime concerns, governance concerns, and shared packages clearly separated.

--- a/scripts/Fix-Psql-Windows.ps1
+++ b/scripts/Fix-Psql-Windows.ps1
@@ -1,0 +1,486 @@
+<#
+.SYNOPSIS
+    Diagnose and fix Windows psql issues for Mishti AI.
+
+.DESCRIPTION
+    On Windows, 'psql' may resolve to a wrong executable (alias, different tool).
+    This script:
+      1. Prints diagnostics (Get-Command, where.exe, --version, -?)
+      2. Detects if psql is NOT the PostgreSQL client
+      3. Offers two fix paths:
+         A) Detect PostgreSQL installer path and prepend to PATH
+         B) Install PostgreSQL client via Chocolatey (if available)
+      4. Validates with a test query
+
+.PARAMETER TestHost
+    PostgreSQL host for validation (default: localhost)
+
+.PARAMETER TestPort
+    PostgreSQL port for validation (default: 5432)
+
+.PARAMETER TestDatabase
+    Database name for validation (default: postgres)
+
+.PARAMETER TestUser
+    Username for validation (default: postgres)
+
+.PARAMETER FixMode
+    Auto-fix mode: 'None', 'PostgresPath', 'Choco' (default: None = diagnose only)
+
+.PARAMETER SkipValidation
+    Skip the connection validation step
+
+.EXAMPLE
+    .\Fix-Psql-Windows.ps1
+    # Diagnose only
+
+.EXAMPLE
+    .\Fix-Psql-Windows.ps1 -FixMode PostgresPath
+    # Attempt to fix PATH using detected PostgreSQL installation
+
+.EXAMPLE
+    $env:PGPASSWORD = "secret"; .\Fix-Psql-Windows.ps1 -TestHost db.example.com -TestPort 5432 -TestUser myuser -TestDatabase mydb
+    # Diagnose and validate connection (password via env var, never printed)
+
+.NOTES
+    SECURITY: This script NEVER prints passwords or secrets.
+    Use PGPASSWORD environment variable for authentication.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$TestHost = "localhost",
+    [int]$TestPort = 5432,
+    [string]$TestDatabase = "postgres",
+    [string]$TestUser = "postgres",
+    [ValidateSet("None", "PostgresPath", "Choco")]
+    [string]$FixMode = "None",
+    [switch]$SkipValidation
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# -----------------------------------------------------------------------------
+# Helper: Write colored output
+# -----------------------------------------------------------------------------
+function Write-Section([string]$Title) {
+    Write-Host "`n========================================" -ForegroundColor Cyan
+    Write-Host " $Title" -ForegroundColor Cyan
+    Write-Host "========================================" -ForegroundColor Cyan
+}
+
+function Write-Ok([string]$Message) {
+    Write-Host "[OK] $Message" -ForegroundColor Green
+}
+
+function Write-Warn([string]$Message) {
+    Write-Host "[WARN] $Message" -ForegroundColor Yellow
+}
+
+function Write-Err([string]$Message) {
+    Write-Host "[ERROR] $Message" -ForegroundColor Red
+}
+
+function Write-Info([string]$Message) {
+    Write-Host "[INFO] $Message" -ForegroundColor Gray
+}
+
+# -----------------------------------------------------------------------------
+# 1. DIAGNOSTICS
+# -----------------------------------------------------------------------------
+Write-Section "psql Diagnostics"
+
+# 1a. Check PowerShell aliases
+Write-Host "`n>> Checking PowerShell aliases for 'psql'..." -ForegroundColor White
+$alias = Get-Alias -Name psql -ErrorAction SilentlyContinue
+if ($alias) {
+    Write-Warn "PowerShell alias found: psql -> $($alias.Definition)"
+    Write-Info "This alias may intercept the real psql executable."
+} else {
+    Write-Ok "No PowerShell alias for 'psql'"
+}
+
+# 1b. Get-Command psql
+Write-Host "`n>> Get-Command psql..." -ForegroundColor White
+$gcm = Get-Command psql -ErrorAction SilentlyContinue
+if ($gcm) {
+    Write-Host "  CommandType : $($gcm.CommandType)"
+    Write-Host "  Name        : $($gcm.Name)"
+    Write-Host "  Source      : $($gcm.Source)"
+    if ($gcm.Source) {
+        $psqlPath = $gcm.Source
+    } else {
+        $psqlPath = $null
+    }
+} else {
+    Write-Err "'psql' not found via Get-Command"
+    $psqlPath = $null
+}
+
+# 1c. where.exe psql (shows ALL matches in PATH)
+Write-Host "`n>> where.exe psql (all PATH matches)..." -ForegroundColor White
+$whereResults = $null
+try {
+    $whereResults = & where.exe psql 2>$null
+    if ($whereResults) {
+        $whereResults | ForEach-Object { Write-Host "  $_" }
+        $allPsqlPaths = @($whereResults)
+    } else {
+        Write-Warn "where.exe found no 'psql' in PATH"
+        $allPsqlPaths = @()
+    }
+} catch {
+    Write-Warn "where.exe failed: $_"
+    $allPsqlPaths = @()
+}
+
+# 1d. psql --version
+Write-Host "`n>> psql --version..." -ForegroundColor White
+$versionOutput = $null
+$isPostgresClient = $false
+try {
+    $versionOutput = & psql --version 2>&1
+    Write-Host "  $versionOutput"
+
+    # PostgreSQL psql outputs: "psql (PostgreSQL) X.Y.Z"
+    if ($versionOutput -match "PostgreSQL") {
+        Write-Ok "Version string contains 'PostgreSQL' - likely correct binary"
+        $isPostgresClient = $true
+    } else {
+        Write-Warn "Version string does NOT contain 'PostgreSQL' - WRONG BINARY?"
+    }
+} catch {
+    Write-Err "psql --version failed: $_"
+}
+
+# 1e. psql -? (help) - PostgreSQL psql has specific flags
+Write-Host "`n>> psql -? (checking help flags)..." -ForegroundColor White
+$helpOutput = $null
+try {
+    $helpOutput = & psql -? 2>&1 | Out-String
+
+    # PostgreSQL psql help contains specific flags like -U, -d, -h, -p
+    $hasUFlag = $helpOutput -match "-U.*username"
+    $hasDFlag = $helpOutput -match "-d.*dbname"
+    $hasHFlag = $helpOutput -match "-h.*hostname"
+    $hasPFlag = $helpOutput -match "-p.*port"
+
+    if ($hasUFlag -and $hasDFlag -and $hasHFlag -and $hasPFlag) {
+        Write-Ok "Help output contains PostgreSQL-specific flags (-U, -d, -h, -p)"
+        $isPostgresClient = $true
+    } else {
+        Write-Warn "Help output MISSING expected PostgreSQL flags"
+        Write-Info "This indicates psql is NOT the PostgreSQL client!"
+        $isPostgresClient = $false
+
+        # Show first 20 lines of help for diagnosis
+        Write-Host "`n  -- First 20 lines of help output --" -ForegroundColor DarkGray
+        $helpOutput -split "`n" | Select-Object -First 20 | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+    }
+} catch {
+    Write-Err "psql -? failed: $_"
+}
+
+# -----------------------------------------------------------------------------
+# 2. DETECTION SUMMARY
+# -----------------------------------------------------------------------------
+Write-Section "Detection Summary"
+
+if ($isPostgresClient) {
+    Write-Ok "psql appears to be the correct PostgreSQL client"
+    if ($psqlPath) {
+        Write-Info "Location: $psqlPath"
+    }
+} else {
+    Write-Err "psql is NOT the PostgreSQL client or is missing!"
+    Write-Host ""
+    Write-Host "Common causes:" -ForegroundColor Yellow
+    Write-Host "  1. Another 'psql' executable (MySQL, etc.) is higher in PATH"
+    Write-Host "  2. PostgreSQL client tools are not installed"
+    Write-Host "  3. PostgreSQL bin directory is not in PATH"
+    Write-Host ""
+}
+
+# -----------------------------------------------------------------------------
+# 3. FIND POSTGRESQL INSTALLATION
+# -----------------------------------------------------------------------------
+Write-Section "Searching for PostgreSQL Installation"
+
+$pgBinPaths = @()
+
+# Check common PostgreSQL installation paths
+$searchPaths = @(
+    "C:\Program Files\PostgreSQL\*\bin",
+    "C:\Program Files (x86)\PostgreSQL\*\bin",
+    "$env:ProgramFiles\PostgreSQL\*\bin",
+    "${env:ProgramFiles(x86)}\PostgreSQL\*\bin",
+    "C:\PostgreSQL\*\bin",
+    "C:\Tools\Postgres\*\bin",
+    "C:\Tools\PostgreSQL\*\bin"
+)
+
+# Also check if current psql is valid, add its parent dir directly
+if ($psqlPath -and (Test-Path $psqlPath)) {
+    $currentBin = Split-Path $psqlPath -Parent
+    if ($currentBin -and (Test-Path (Join-Path $currentBin "psql.exe"))) {
+        if ($pgBinPaths -notcontains $currentBin) {
+            $pgBinPaths += $currentBin
+            Write-Info "Found PostgreSQL bin (current): $currentBin"
+        }
+    }
+}
+
+foreach ($pattern in $searchPaths) {
+    $matches = Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue | Where-Object { $_.PSIsContainer }
+    foreach ($dir in $matches) {
+        $psqlExe = Join-Path $dir.FullName "psql.exe"
+        if (Test-Path $psqlExe) {
+            if ($pgBinPaths -notcontains $dir.FullName) {
+                $pgBinPaths += $dir.FullName
+                Write-Info "Found PostgreSQL bin: $($dir.FullName)"
+            }
+        }
+    }
+}
+
+# Also check via registry
+try {
+    $regPaths = @(
+        "HKLM:\SOFTWARE\PostgreSQL\Installations",
+        "HKLM:\SOFTWARE\WOW6432Node\PostgreSQL\Installations"
+    )
+    foreach ($regPath in $regPaths) {
+        if (Test-Path $regPath) {
+            Get-ChildItem $regPath -ErrorAction SilentlyContinue | ForEach-Object {
+                $baseDir = (Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue)."Base Directory"
+                if ($baseDir) {
+                    $binDir = Join-Path $baseDir "bin"
+                    $psqlExe = Join-Path $binDir "psql.exe"
+                    if ((Test-Path $psqlExe) -and ($pgBinPaths -notcontains $binDir)) {
+                        $pgBinPaths += $binDir
+                        Write-Info "Found PostgreSQL bin (registry): $binDir"
+                    }
+                }
+            }
+        }
+    }
+} catch {
+    Write-Info "Registry search skipped: $_"
+}
+
+# Sort by version (newest first, assuming version in path like PostgreSQL\16\bin)
+# Ensure result is always an array (Sort-Object returns $null for empty input)
+$pgBinPaths = @($pgBinPaths | Sort-Object -Descending)
+
+if ($pgBinPaths.Count -eq 0) {
+    Write-Warn "No PostgreSQL installation found on this system"
+} else {
+    Write-Ok "Found $($pgBinPaths.Count) PostgreSQL installation(s)"
+    $pgBinPaths | ForEach-Object { Write-Host "  - $_" }
+}
+
+# Check Chocolatey
+Write-Host "`n>> Checking for Chocolatey..." -ForegroundColor White
+$chocoAvailable = $null -ne (Get-Command choco -ErrorAction SilentlyContinue)
+if ($chocoAvailable) {
+    Write-Ok "Chocolatey is available"
+} else {
+    Write-Info "Chocolatey is not installed"
+}
+
+# -----------------------------------------------------------------------------
+# 4. FIX OPTIONS
+# -----------------------------------------------------------------------------
+Write-Section "Fix Options"
+
+if ($isPostgresClient) {
+    Write-Ok "No fix needed - psql is working correctly"
+} else {
+    Write-Host "Available fix options:" -ForegroundColor White
+    Write-Host ""
+
+    if ($pgBinPaths.Count -gt 0) {
+        Write-Host "  [A] PostgresPath - Prepend PostgreSQL bin to PATH" -ForegroundColor Green
+        Write-Host "      Recommended path: $($pgBinPaths[0])"
+        Write-Host "      Run: .\Fix-Psql-Windows.ps1 -FixMode PostgresPath"
+        Write-Host ""
+    }
+
+    if ($chocoAvailable) {
+        Write-Host "  [B] Choco - Install PostgreSQL client via Chocolatey" -ForegroundColor Green
+        Write-Host "      Run: .\Fix-Psql-Windows.ps1 -FixMode Choco"
+        Write-Host ""
+    } elseif ($pgBinPaths.Count -eq 0) {
+        Write-Host "  [B] Install Chocolatey first, then use -FixMode Choco" -ForegroundColor Yellow
+        Write-Host "      Or download PostgreSQL from: https://www.postgresql.org/download/windows/"
+        Write-Host ""
+    }
+
+    if ($pgBinPaths.Count -eq 0 -and -not $chocoAvailable) {
+        Write-Host "  [Manual] Download PostgreSQL installer from:" -ForegroundColor Yellow
+        Write-Host "           https://www.postgresql.org/download/windows/"
+        Write-Host ""
+    }
+}
+
+# -----------------------------------------------------------------------------
+# 5. APPLY FIX (if requested)
+# -----------------------------------------------------------------------------
+if ($FixMode -ne "None") {
+    Write-Section "Applying Fix: $FixMode"
+
+    switch ($FixMode) {
+        "PostgresPath" {
+            if ($pgBinPaths.Count -eq 0) {
+                Write-Err "Cannot apply PostgresPath fix - no PostgreSQL installation found"
+                Write-Host "Install PostgreSQL first or use -FixMode Choco"
+                exit 1
+            }
+
+            $targetBin = $pgBinPaths[0]
+            Write-Info "Prepending to PATH: $targetBin"
+
+            # Prepend to current session PATH
+            $env:PATH = "$targetBin;$env:PATH"
+            Write-Ok "PATH updated for current session"
+
+            # Instructions for permanent fix
+            Write-Host ""
+            Write-Host "To make this permanent, run (as Administrator):" -ForegroundColor Yellow
+            Write-Host @"
+  `$currentPath = [Environment]::GetEnvironmentVariable('PATH', 'Machine')
+  if (`$currentPath -notlike "*$targetBin*") {
+      [Environment]::SetEnvironmentVariable('PATH', "$targetBin;`$currentPath", 'Machine')
+  }
+"@ -ForegroundColor DarkGray
+            Write-Host ""
+        }
+
+        "Choco" {
+            if (-not $chocoAvailable) {
+                Write-Err "Chocolatey is not installed"
+                Write-Host "Install Chocolatey from: https://chocolatey.org/install"
+                exit 1
+            }
+
+            Write-Info "Installing postgresql via Chocolatey (requires elevation)..."
+            Write-Host "Running: choco install postgresql --confirm" -ForegroundColor DarkGray
+
+            try {
+                # Check if running elevated
+                $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+                if (-not $isAdmin) {
+                    Write-Warn "Not running as Administrator - Chocolatey install may fail"
+                    Write-Host "Re-run this script as Administrator, or run manually:" -ForegroundColor Yellow
+                    Write-Host "  choco install postgresql --confirm" -ForegroundColor DarkGray
+                } else {
+                    & choco install postgresql --confirm
+                    if ($LASTEXITCODE -eq 0) {
+                        Write-Ok "PostgreSQL installed via Chocolatey"
+                        Write-Warn "You may need to restart your terminal for PATH changes to take effect"
+
+                        # Try to find the new installation
+                        $newPaths = Get-ChildItem "C:\Program Files\PostgreSQL\*\bin" -ErrorAction SilentlyContinue
+                        if ($newPaths) {
+                            $latestBin = ($newPaths | Sort-Object -Descending | Select-Object -First 1).FullName
+                            $env:PATH = "$latestBin;$env:PATH"
+                            Write-Ok "PATH updated for current session: $latestBin"
+                        }
+                    } else {
+                        Write-Err "Chocolatey install failed with exit code $LASTEXITCODE"
+                        exit 1
+                    }
+                }
+            } catch {
+                Write-Err "Chocolatey install failed: $_"
+                exit 1
+            }
+        }
+    }
+}
+
+# -----------------------------------------------------------------------------
+# 6. VALIDATION
+# -----------------------------------------------------------------------------
+if (-not $SkipValidation) {
+    Write-Section "Validation"
+
+    # Re-check psql after potential fix
+    Write-Host ">> Re-checking psql..." -ForegroundColor White
+    $gcmAfter = Get-Command psql -ErrorAction SilentlyContinue
+    if ($gcmAfter) {
+        Write-Info "psql location: $($gcmAfter.Source)"
+
+        $versionAfter = & psql --version 2>&1
+        Write-Info "psql version: $versionAfter"
+
+        if ($versionAfter -match "PostgreSQL") {
+            Write-Ok "psql is now the PostgreSQL client"
+        } else {
+            Write-Err "psql is still NOT the PostgreSQL client"
+            exit 1
+        }
+    } else {
+        Write-Err "psql still not found"
+        exit 1
+    }
+
+    # Test connection (only if PGPASSWORD is set or localhost)
+    Write-Host "`n>> Testing connection..." -ForegroundColor White
+
+    if (-not $env:PGPASSWORD -and $TestHost -ne "localhost" -and $TestHost -ne "127.0.0.1") {
+        Write-Warn "PGPASSWORD not set - skipping remote connection test"
+        Write-Info "To test: `$env:PGPASSWORD = 'yourpassword'; .\Fix-Psql-Windows.ps1"
+    } else {
+        Write-Info "Connecting to $TestHost`:$TestPort as $TestUser..."
+        Write-Host "(Password passed via PGPASSWORD env var - not printed)" -ForegroundColor DarkGray
+
+        try {
+            $testResult = & psql -h $TestHost -p $TestPort -d $TestDatabase -U $TestUser -w -c "SELECT 1 AS connection_test;" 2>&1
+
+            if ($LASTEXITCODE -eq 0 -and $testResult -match "connection_test") {
+                Write-Ok "Connection test PASSED"
+                Write-Host $testResult -ForegroundColor DarkGray
+            } else {
+                Write-Warn "Connection test returned exit code $LASTEXITCODE"
+                Write-Host $testResult -ForegroundColor DarkGray
+
+                if ($testResult -match "password authentication failed" -or $testResult -match "no password supplied") {
+                    Write-Info "Set PGPASSWORD environment variable with correct password"
+                } elseif ($testResult -match "could not connect") {
+                    Write-Info "Check host, port, and network connectivity"
+                }
+            }
+        } catch {
+            Write-Err "Connection test failed: $_"
+        }
+    }
+}
+
+# -----------------------------------------------------------------------------
+# 7. SUMMARY
+# -----------------------------------------------------------------------------
+Write-Section "Summary"
+
+$gcmFinal = Get-Command psql -ErrorAction SilentlyContinue
+if ($gcmFinal -and (& psql --version 2>&1) -match "PostgreSQL") {
+    Write-Ok "psql is correctly configured"
+    Write-Host "  Location: $($gcmFinal.Source)"
+    Write-Host "  Version:  $(& psql --version 2>&1)"
+    exit 0
+} else {
+    Write-Err "psql is NOT correctly configured"
+    Write-Host ""
+    Write-Host "Next steps:" -ForegroundColor Yellow
+    if ($pgBinPaths.Count -gt 0) {
+        Write-Host "  1. Run: .\Fix-Psql-Windows.ps1 -FixMode PostgresPath"
+    } elseif ($chocoAvailable) {
+        Write-Host "  1. Run (as Admin): .\Fix-Psql-Windows.ps1 -FixMode Choco"
+    } else {
+        Write-Host "  1. Install PostgreSQL from https://www.postgresql.org/download/windows/"
+        Write-Host "  2. Re-run this script"
+    }
+    exit 1
+}

--- a/scripts/mt.ps1
+++ b/scripts/mt.ps1
@@ -1,0 +1,7 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Args
+)
+
+# Preferred CLI entry point. Delegates to the legacy CLI implementation during migration.
+& "$PSScriptRoot\rgpt.ps1" @Args

--- a/scripts/mt_health.ps1
+++ b/scripts/mt_health.ps1
@@ -1,0 +1,7 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Args
+)
+
+# Preferred health entry point. Keeps the legacy health implementation unchanged during migration.
+& "$PSScriptRoot\rgpt_health.ps1" @Args

--- a/scripts/ops/Verify-RuntimeTimeline.ps1
+++ b/scripts/ops/Verify-RuntimeTimeline.ps1
@@ -1,5 +1,5 @@
 # RGPT-E2-TIMELINE-VERIFY-PS-01
-# Purpose: Validate RocketGPT Runtime Timeline (JSONL)
+# Purpose: Validate the Mishti AI Runtime Timeline (JSONL)
 # Usage:
 #   pwsh .\scripts\ops\Verify-RuntimeTimeline.ps1 -Path ".\runtime_timeline.jsonl"
 

--- a/scripts/rgpt.ps1
+++ b/scripts/rgpt.ps1
@@ -78,13 +78,12 @@ switch ($Command.ToLower()) {
 
         Start-Sleep -Seconds 3
         $r = gh run list --workflow "Vercel Throttled Deploy" --limit 1 --json databaseId,updatedAt | ConvertFrom-Json
-        if (-not $r) { Write-Host "No run found — check GitHub." -ForegroundColor Yellow; break }
+        if (-not $r) { Write-Host "No run found. Check GitHub." -ForegroundColor Yellow; break }
         $runId = $r[0].databaseId
         Write-Host "Run ID: $runId"
 
         if (-not $opts.Wait) { break }
 
-        # Wait mode: poll until completed and print gate decision
         do {
           $j = gh run view $runId --json status,conclusion | ConvertFrom-Json
           $resultText = "(n/a)"
@@ -98,11 +97,10 @@ switch ($Command.ToLower()) {
     }
     "deploy-status" {
         if ($Args.Count -lt 1) {
-            Write-Host "Usage: ./scripts/rgpt.ps1 deploy-status <RunId>" -ForegroundColor Yellow
+            Write-Host "Usage: ./scripts/mt.ps1 deploy-status <RunId>  (legacy: ./scripts/rgpt.ps1 deploy-status <RunId>)" -ForegroundColor Yellow
             break
         }
         $runId = $Args[0]
-        # wait until completed, then show decision lines
         do {
           $j = gh run view $runId --json status,conclusion | ConvertFrom-Json
           $resultText = "(n/a)"
@@ -115,22 +113,24 @@ switch ($Command.ToLower()) {
         gh run view $runId --log | Select-String -Pattern "Decide if deploy allowed", "Over 30 minutes", "Under 30 minutes", "Deploying to Vercel", "Skipping deploy"
     }
     "help" {
-        Write-Host "`nRocketGPT CLI (rgpt.ps1)" -ForegroundColor Cyan
-        Write-Host "Operate RocketGPT from PowerShell: health, runs, logs, deploy, and plan views.`n"
+        Write-Host "`nMishti AI CLI compatibility script" -ForegroundColor Cyan
+        Write-Host "Preferred command: ./scripts/mt.ps1. Legacy compatibility alias: ./scripts/rgpt.ps1.`n"
         Write-Host "USAGE:" -ForegroundColor Yellow
-        Write-Host "  ./scripts/rgpt.ps1 health                 # Health snapshot (runs + plan + verdict)"
-        Write-Host "  ./scripts/rgpt.ps1 runs [--limit N]       # Recent Self-Improve runs (table)"
-        Write-Host "  ./scripts/rgpt.ps1 logs                   # Logs for the latest run"
-        Write-Host "  ./scripts/rgpt.ps1 logs --run <RunId>     # Logs for a specific run"
-        Write-Host "  ./scripts/rgpt.ps1 logs --limit N         # Logs for last N runs"
-        Write-Host "  ./scripts/rgpt.ps1 logs --last-failed     # Logs for most recent failed run"
-        Write-Host "  ./scripts/rgpt.ps1 deploy [--wait]        # Trigger throttled Vercel deploy (with 30m gate)"
-        Write-Host "  ./scripts/rgpt.ps1 deploy-status <RunId>  # Wait + print gate decision for a throttled deploy run"
+        Write-Host "  ./scripts/mt.ps1 health                   # Preferred health snapshot command"
+        Write-Host "  ./scripts/mt.ps1 runs [--limit N]         # Preferred recent Self-Improve runs command"
+        Write-Host "  ./scripts/mt.ps1 logs                     # Preferred logs command"
+        Write-Host "  ./scripts/mt.ps1 logs --run <RunId>       # Preferred logs command for a specific run"
+        Write-Host "  ./scripts/mt.ps1 logs --limit N           # Preferred logs command for last N runs"
+        Write-Host "  ./scripts/mt.ps1 logs --last-failed       # Preferred logs command for the most recent failed run"
+        Write-Host "  ./scripts/mt.ps1 deploy [--wait]          # Preferred throttled Vercel deploy command"
+        Write-Host "  ./scripts/mt.ps1 deploy-status <RunId>    # Preferred gate decision command"
+        Write-Host "`nLegacy compatibility:"
+        Write-Host "  ./scripts/rgpt.ps1 <command>              # Still supported during phased migration"
         return
     }
     default {
         Write-Host "Unknown command: $Command" -ForegroundColor Red
-        Write-Host "Try: ./scripts/rgpt.ps1 help"
+        Write-Host "Try: ./scripts/mt.ps1 help  (legacy: ./scripts/rgpt.ps1 help)"
         exit 1
     }
 }

--- a/scripts/rgpt_health.ps1
+++ b/scripts/rgpt_health.ps1
@@ -1,5 +1,5 @@
 Write-Host "`n==========================="
-Write-Host " RocketGPT Health Snapshot "
+Write-Host " Mishti AI Health Snapshot "
 Write-Host "===========================`n"
 
 # -------------------------------
@@ -29,18 +29,19 @@ $latestRun = gh run list --repo "proteaNirav/rocketgpt" `
   ConvertFrom-Json
 
 if (-not $latestRun) {
-    Write-Host "No runs found — health UNKNOWN" -ForegroundColor Yellow
+    Write-Host "No runs found ï¿½ health UNKNOWN" -ForegroundColor Yellow
     exit
 }
 
 $latest = $latestRun
 
 if ($latest.status -eq "completed" -and $latest.conclusion -eq "success") {
-    Write-Host "? RocketGPT Self-Improve is Healthy" -ForegroundColor Green
+    Write-Host "? Mishti AI Self-Improve is Healthy" -ForegroundColor Green
 }
 elseif ($latest.status -eq "completed" -and $latest.conclusion -ne "success") {
-    Write-Host "? Self-Improve completed but failed — needs attention" -ForegroundColor Yellow
+    Write-Host "? Self-Improve completed but failed ï¿½ needs attention" -ForegroundColor Yellow
 }
 else {
     Write-Host "? Self-Improve is in a bad state" -ForegroundColor Red
 }
+

--- a/scripts/self-improve/README.md
+++ b/scripts/self-improve/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-These scripts support RocketGPT's self-improvement subsystem. All scripts follow strict safety guidelines to prevent unauthorized code modifications.
+These scripts support Mishti AI's self-improvement subsystem. All scripts follow strict safety guidelines to prevent unauthorized code modifications.
+
+For operator-facing CLI access, prefer `./scripts/mt.ps1` and treat `./scripts/rgpt.ps1` as a temporary compatibility alias.
 
 **Last Audited**: 2025-12-23
 **Safety Status**: ✅ All scripts safe for use
@@ -245,3 +247,4 @@ node scripts/self-improve/execute.js
 
 **Version**: 1.0
 **Last Updated**: 2025-12-23
+

--- a/scripts/self-improve/patcher.js
+++ b/scripts/self-improve/patcher.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// RocketGPT Self-Improve patcher (placeholder)
+// Mishti AI Self-Improve patcher (placeholder)
 //
 // Responsibility in v4 Core AI:
 // - NEVER fail the workflow if there is no active improvement.

--- a/scripts/ui-healer/ui-healer.js
+++ b/scripts/ui-healer/ui-healer.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Simple UI healer for RocketGPT v3_full
+// Simple UI healer for the Mishti AI legacy v3_full surface
 
 const { execSync } = require("node:child_process");
 const process = require("node:process");
@@ -61,7 +61,7 @@ async function main() {
 
   // 2) Build a compact prompt with opinionated UI rules
   const prompt = `
-You are RocketGPT's UI Healer. You review diffs of the Next.js app in "rocketgpt_v3_full/webapp/next" and suggest minimal improvements.
+You are Mishti AI's UI Healer. You review diffs of the Next.js app in "rocketgpt_v3_full/webapp/next" and suggest minimal improvements.
 
 Rules:
 - Keep all business logic and data flow as-is.
@@ -98,7 +98,7 @@ Output format (very important):
     messages: [
       {
         role: "system",
-        content: "You are a senior frontend engineer and UI healer for RocketGPT."
+        content: "You are a senior frontend engineer and UI healer for Mishti AI."
       },
       { role: "user", content: prompt }
     ]
@@ -126,7 +126,7 @@ Output format (very important):
   if (GITHUB_TOKEN && GITHUB_REPOSITORY) {
     const commentBody = {
       body: [
-        "### 🤖 RocketGPT UI Healer Report",
+        "### 🤖 Mishti AI UI Healer Report",
         "",
         content,
         "",


### PR DESCRIPTION
This PR performs a controlled, low-risk branding migration from RocketGPT to Mishti AI / Yukti across active documentation, workflow display surfaces, operator help text, and CLI entry points.

Included:
- Mishti AI / Yukti platform-facing documentation updates
- mt CLI compatibility wrappers
- active workflow/help/operator branding cleanup
- helper/config branding polish on active surfaces

Commits in this PR:
1. docs: rebrand active platform-facing surfaces to Mishti AI and Yukti
2. chore: polish active helper and config branding surfaces
3. chore: add mt CLI compatibility wrappers and refresh operator-facing help

Explicitly excluded:
- package names
- import paths
- RGPT_* env vars
- src/rgpt namespaces
- runtime/ledger/db identifiers
- archived/history/evidence artifacts
- .rocketgpt compatibility paths
- rocketgpt_v3_full and other compatibility-heavy areas

The `mt` CLI is introduced as the preferred command path while preserving `rgpt` commands as compatibility aliases.

This is the safe stopping point for presentation-only migration work. Technical identifiers and compatibility tokens remain unchanged intentionally.